### PR TITLE
Fixing issue when merging from master to demo

### DIFF
--- a/lib/epi_deploy/git.rb
+++ b/lib/epi_deploy/git.rb
@@ -135,7 +135,7 @@ namespace :git do
             `git checkout demo`
             `git pull`
 
-            `git merge --no-ff v#{new_version}`
+            `git merge --no-edit --no-ff v#{new_version}`
             `git push origin demo`
 
             deploy? 'demo'  
@@ -220,7 +220,7 @@ namespace :git do
             `git checkout production`
             `git pull`
 
-            `git merge --no-ff #{selected_tag}`
+            `git merge --no-edit --no-ff #{selected_tag}`
             `git push origin production`
 
             deploy? 'production'

--- a/lib/epi_deploy/version.rb
+++ b/lib/epi_deploy/version.rb
@@ -1,3 +1,3 @@
 module EpiDeploy
-  VERSION = "1.0.7"
+  VERSION = "1.0.8"
 end


### PR DESCRIPTION
Added --no-edit option to the git merge commands. Previously it was causing the merge to hang on mine and Eve's machines. --no-edit removes the ability for the user to add a commit message when merging (which isn't needed anyway).

Bumped gem version to 1.0.8
