### PR TITLE
Fix for Windows-based git tag issue breaking deployment

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,6 @@ gemspec
 
 group :development do
   gem "rspec", '~> 3.1'
-  gem "aruba", '~> 0.6'
+  gem "aruba", '~> 0.7.0'
   gem "aruba-doubles", '~> 1.2'
 end

--- a/epi_deploy.gemspec
+++ b/epi_deploy.gemspec
@@ -12,11 +12,11 @@ Gem::Specification.new do |gem|
   gem.summary       = "eD"
   gem.homepage      = "http://www.epigenesys.co.uk"
 
-  gem.files         = `git ls-files`.split($/) - ['config/production.rb']
+  gem.files         = `git ls-files`.split($/) - ['config/deploy/production.rb']
   gem.executables   = gem.files.grep(%r{^bin/}).map{ |f| File.basename(f) }
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
-  
+
   gem.add_dependency('slop', '~> 3.6')
   gem.add_dependency('git',  '~> 1.2')
 end

--- a/lib/epi_deploy/git_wrapper.rb
+++ b/lib/epi_deploy/git_wrapper.rb
@@ -7,41 +7,41 @@ module EpiDeploy
     def on_master?
       git.current_branch == "master"
     end
-    
+
     def pending_changes?
       git.status.changed.any?
     end
-    
+
     def pull
       git.pull
     end
-    
+
     def commit(message)
       git.commit_all message
     end
-    
+
     def push(branch, options = {force: false, tags: true})
       git.push 'origin', branch, options
     end
-    
+
     def add(files = nil)
       git.add files
     end
-    
+
     def short_commit_hash
       git.log.first.sha[0..6]
     end
-    
+
     def tag(tag_name)
       git.add_tag(tag_name, annotate: true, message: tag_name)
     end
-    
+
     def get_commit(git_reference)
       if git_reference == :latest
         print_failure_and_abort("There is no latest release. Create one, or specify a reference with --ref") if tag_list.empty?
         git_reference = tag_list.first
       end
-      
+
       git_object_type = git.lib.object_type(git_reference)
 
       case git_object_type
@@ -50,20 +50,20 @@ module EpiDeploy
         else nil
       end
     end
-    
+
     def change_branch_commit(branch, commit)
       Kernel.system "git branch -f #{branch} #{commit}"
       self.push branch, force: true, tags: true
     end
-    
+
     def tag_list(options = {limit: 5})
-      @tag_list ||= `git for-each-ref --sort=taggerdate --format '%(tag)' refs/tags`.split.reverse
+      @tag_list ||= `git for-each-ref --sort=taggerdate --format '%(tag)' refs/tags`.gsub("'", '').split.reverse
     end
- 
+
     private
       def git
         @git ||= ::Git.open(Dir.pwd)
       end
-    
+
   end
 end

--- a/lib/epi_deploy/version.rb
+++ b/lib/epi_deploy/version.rb
@@ -1,3 +1,3 @@
 module EpiDeploy
-  VERSION = "2.0.1"
+  VERSION = "2.0.2"
 end

--- a/spec/support/aruba_helper.rb
+++ b/spec/support/aruba_helper.rb
@@ -6,11 +6,11 @@ require 'aruba-doubles'
 RSpec.configure do |config|
   config.include Aruba::Api
   config.include ArubaDoubles
-  
+
   config.before do
     ArubaDoubles::Double.setup
   end
-  
+
   config.after do
     ArubaDoubles::Double.teardown
   end
@@ -19,23 +19,24 @@ end
 def setup_aruba_and_git
   local_repo = File.expand_path('../../tmp/local_repo', __FILE__)
   @dirs = [local_repo]
-  
+
   restore_env
-  clean_current_dir
-    
+  `rm -rf #{local_repo}`
+  `mkdir -p #{local_repo}`
+
   `mkdir -p #{local_repo}/config/initializers`
   `mkdir -p #{local_repo}/config/deploy`
-  
+
   `echo > #{local_repo}/config/initializers/.gitkeep`
   `echo > #{local_repo}/config/deploy/production.rb`
-  
+
   g = Git.init(local_repo)
   g.add
   g.commit('initial commit')
-  
+
   # Set the remote repo to the local, works the same as an actual remote
   g.add_remote('origin', local_repo)
-  
+
   `cd #{local_repo} && git push -u origin master &> /dev/null`
-  
+
 end


### PR DESCRIPTION
Fixes an issue with 'git tag' returning quotes when run on Windows, and that caused Windows-based deployments to break.