### PR TITLE
Pass through `target={release}` to Capistrano

### DIFF
--- a/lib/epi_deploy/release.rb
+++ b/lib/epi_deploy/release.rb
@@ -8,7 +8,7 @@ module EpiDeploy
 
     MONTHS = %w(jan feb mar apr may jun jul aug sep oct nov dec)
 
-    attr_accessor :tag, :commit
+    attr_accessor :reference, :tag, :commit
 
     def create!
       return print_failure_and_abort 'You can only create a release on the master branch. Please switch to master and try again.' unless git_wrapper.on_master?
@@ -63,8 +63,9 @@ module EpiDeploy
     def self.find(reference)
       release = self.new
       commit = release.git_wrapper.get_commit(reference)
-      return nil if commit.nil?
+      print_failure_and_abort("Cannot find commit for reference '#{reference}'") if commit.nil?
       release.commit = commit
+      release.reference = reference
       release
     end
 
@@ -88,9 +89,8 @@ module EpiDeploy
           "deploy"
         end
 
-        Kernel.system "bundle exec cap #{environment} #{task_to_run}"
+        Kernel.system "bundle exec cap #{environment} #{task_to_run} target=#{reference}"
       end
-
 
       def stages_extractor
         @stages_extractor ||= StagesExtractor.new

--- a/spec/lib/epi_deploy/release_spec.rb
+++ b/spec/lib/epi_deploy/release_spec.rb
@@ -22,7 +22,7 @@ describe EpiDeploy::Release do
 
   let(:git_wrapper) { MockGit.new }
   before do
-    allow(subject).to receive_messages(git_wrapper: git_wrapper, app_version: double(bump!: 42, version_file_path: ''))
+    allow(subject).to receive_messages(reference: 'test', git_wrapper: git_wrapper, app_version: double(bump!: 42, version_file_path: ''))
   end
 
   describe "#create!" do
@@ -83,12 +83,17 @@ describe EpiDeploy::Release do
   describe "#deploy!" do
     it "runs the capistrano deploy command for each of the environments given" do
       Dir.chdir(File.join(File.dirname(__FILE__), '../..', 'fixtures')) do
-        expect(Kernel).to receive(:system).with('bundle exec cap demo deploy')
-        expect(Kernel).to receive(:system).with('bundle exec cap production deploy_all')
-        subject.deploy! %w(demo production)
+        expect(Kernel).to receive(:system).with('bundle exec cap demo deploy target=test').and_return(true)
+        expect(Kernel).to receive(:system).with('bundle exec cap production deploy_all target=test').and_return(true)
+
+        expect do
+          # Suppress output from epiDeploy
+          allow_any_instance_of(IO).to receive(:puts)
+
+          subject.deploy! %w(demo production)
+        end.to_not raise_error
       end
     end
-
   end
 
 end


### PR DESCRIPTION
Our team makes use of the `target={release}` environment variable to record what has been deployed to which demo site.

This change will let epiDeploy pass that through to Capistrano, so it can then be handled as part of the deployment process.