### PR TITLE
Add deprecation warnings and improve branch deletion for tag deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,12 +27,13 @@ gem 'epi_deploy', github: 'epigenesys/epi_deploy'
 And then execute:
 
 ```sh
-$ bundle install
+bundle install
 ```
 
 ## Usage
 
 ### Initial Setup
+
 No initial setup is required as prerequisites are checked automatically before each command is run.
 
 ### Creating a release
@@ -41,8 +42,8 @@ Creating a release without a commit is now the default behaviour, and in a futur
 
 Releasing creates a Git tag in the format `YYYYmonDD-HHMM-<short_commit_hash>-v<version>`, where `<short_commit_hash>` is the first seven characters of the hash of the latest commit on the main branch, and `<version>` is one more than the `<version>` in the previous release tag. The tag is pushed to the remote repository. Releasing can only be done on the `main` or `master` branch.
 
-```bash
-$ ed release
+```sh
+ed release
 ```
 
 To revert back to the previous behaviour of creating a release with a commit, set `EpiDeploy.create_release_commit` to `true` in your `config/epi_deploy.rb`. This raises a deprecation warning each time a release is made.
@@ -73,20 +74,20 @@ If `EpiDeploy.create_release_commit = true`, then this will call `git reset` to 
 
 The simplest way to deploy is at the same time as creating a commit, by passing the `--deploy` or `-d` flag with the given environment(s) after creating the release. Separate each environment with a colon.
 
-```bash
-$ ed release --deploy demo:production
+```sh
+ed release --deploy demo:production
 ```
 
 Alternatively, you can deploy separately to creating a release using the `deploy` command. This deploys the latest release to the given environment(s) by default. Separate each environment with a space.
 
-```bash
-$ ed deploy demo production
+```sh
+ed deploy demo production
 ```
 
 You can also pass the `--ref` or `-r` flag to specify which tag, commit, or branch to deploy to the given environment(s). If the flag is provided without a reference you will be prompted to choose from the latest releases.
 
-```bash
-$ ed deploy demo production --ref <reference>
+```sh
+ed deploy demo production --ref <reference>
 ```
 
 ### Deploy to multiple customers
@@ -95,38 +96,38 @@ If you want to deploy to multiple customers, you can set it up as following:
 
 1. In `config/deploy`, create one config file for the environment you want to deploy to. (e.g. `production.rb`)
 
-  * In this file, include the setting for stage:
+   In this file, include the setting for stage:
 
-    ```
-    set :stage, :production
-    ```
+   ```rb
+   set :stage, :production
+   ```
 
-    Also include any common settings across customers:
+   Also include any common settings across customers:
 
-    ```
-    set :branch, 'production'
-    ```
+   ```rb
+   set :branch, 'production'
+   ```
 
-2. In `config/deploy`, create one config file with the name in following format: `{stage}.{customer}.rb` (e.g. `production.epigenesys.rb`)
+1. In `config/deploy`, create one config file with the name in following format: `{stage}.{customer}.rb` (e.g. `production.epigenesys.rb`)
 
-  * Include the following content (remember to replace the name of the stage and customer):
+   Include the following content (remember to replace the name of the stage and customer):
 
-    ```
-    load File.expand_path('../production.rb', __FILE__)
-    ```
+   ```rb
+   load File.expand_path('../production.rb', __FILE__)
+   ```
 
-  * Also include any other customer specific settings:
+   Also include any other customer specific settings:
 
-    ```
-    set :current_customer, 'epigenesys'
-    server fetch(:server), user: fetch(:user), roles: %w{web app db}
-    ```
+   ```rb
+   set :current_customer, 'epigenesys'
+   server fetch(:server), user: fetch(:user), roles: %w{web app db}
+   ```
 
-3. Include this line in `Capfile`:
+1. Include this line in `Capfile`:
 
-  ```
-  require 'capistrano/epi_deploy'
-  ```
+   ```rb
+   require 'capistrano/epi_deploy'
+   ```
 
 Running `ed release -d production` will now deploy the latest release of the code to all customers.
 
@@ -134,9 +135,11 @@ You can also deploy to a specific customer by doing e.g. `ed release -d producti
 
 You can also deploy to all customers for a given environment by running e.g. `cap production deploy_all`.
 
-# Moving to tags for stages
+### Moving to tags for stages
 
-Using branches for stages, i.e. demo and production branches, can clutter up your branches screen. This can be particularly awkward when running CI and keeping track of multiple active branches. To resolve this you can optionally configure epi_deploy to use tags for this instead of branches.
+**Deploying with tags will become the only option in the next major release, and deploying with branches will be removed.**
+
+Using branches for stages, i.e. demo and production branches, can clutter up your branches screen. This can be particularly awkward when running CI and keeping track of multiple active branches. To resolve this you can configure `epi_deploy` to use tags for this instead of branches.
 
 Tags will be automatically created for each successful deployment with the format `deploy-<environment>.<stage>-<timestamp>`, for example `deploy-production.epigenesys-2024_10_03-12_20_09`, and pushed to the remote.
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ No initial setup is required as prerequisites are checked automatically before e
 
 ### Creating a release
 
-Creating a release without a commit is now the default behaviour, and in a future version will become the only way to make releases. It is recommended that you migrate your workflow as soon as possible to releasing without a commit.
+**Creating commitless releases is now the default behaviour, and in a future version will be the only way to make releases. It is recommended that you migrate your workflow as soon as possible to commitless releases.**
 
 Releasing creates a Git tag in the format `YYYYmonDD-HHMM-<short_commit_hash>-v<version>`, where `<short_commit_hash>` is the first seven characters of the hash of the latest commit on the main branch, and `<version>` is one more than the `<version>` in the previous release tag. The tag is pushed to the remote repository. Releasing can only be done on the `main` or `master` branch.
 
@@ -45,14 +45,14 @@ Releasing creates a Git tag in the format `YYYYmonDD-HHMM-<short_commit_hash>-v<
 ed release
 ```
 
-To revert back to the previous behaviour of creating a release with a commit, set `EpiDeploy.create_release_commit` to `true` in your `config/epi_deploy.rb`. This raises a deprecation warning each time a release is made.
+You can revert back to creating commitful releaess, by setting `EpiDeploy.create_release_commit` to `true` in your `config/epi_deploy.rb`. This raises a deprecation warning each time a release is made.
 
 ```rb
 # config/epi_deploy.rb
 EpiDeploy.create_release_commit = true
 ```
 
-Creating a release with a commit creates or bumps the version in `config/initializers/version.rb`, setting an `APP_VERSION` constant. This is read instead of the latest release tag when determining what `<version>` to use.
+Creating commitful releases sets or bumps the version in `config/initializers/version.rb`, setting an `APP_VERSION` constant. This is read instead of the latest release tag when determining what `<version>` to use.
 
 ```rb
 # config/initializers/version.rb
@@ -67,7 +67,7 @@ By default, creating a release is prevented if your working tree or index is dir
 ed release --allow-dirty
 ```
 
-If `EpiDeploy.create_release_commit = true`, then this will call `git reset` to unstage any staged changes to ensure that only the change to the `version.rb` is committed.
+When creating commitful releases, then this will call `git reset` to unstage any staged changes before to ensure that only the change to the `version.rb` is committed.
 
 ### Deploying a release
 
@@ -135,9 +135,9 @@ You can also deploy to a specific customer by doing e.g. `ed release -d producti
 
 You can also deploy to all customers for a given environment by running e.g. `cap production deploy_all`.
 
-### Moving to tags for stages
+### Moving to branchless deployments
 
-**Deploying with tags will become the only option in the next major release, and deploying with branches will be removed.**
+**Branchless deployment will be the only option in a future version, and branchful deployments will be removed.**
 
 Using branches for stages, i.e. demo and production branches, can clutter up your branches screen. This can be particularly awkward when running CI and keeping track of multiple active branches. To resolve this you can configure `epi_deploy` to use tags for this instead of branches.
 

--- a/README.md
+++ b/README.md
@@ -6,9 +6,8 @@ This gem provides a convenient interface for creating releases and deploying usi
 
 ### Branch Notes
 
-* `main` / `master` should only contain deployable code.
-* Each deployment environment has its own branch.
-* Remote repository is assumed to be named 'origin'
+* You can only create a release from `main` / `master`.
+* The remote repository is assumed to be named `origin`.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -35,27 +35,55 @@ $ bundle install
 ### Initial Setup
 No initial setup is required as prerequisites are checked automatically before each command is run.
 
-### Commands
+### Creating a release
 
-This command will bump the version in config/initializers/version.rb, create a Git tag in the format YYYYmonDD-HHMM-&lt;short_commit_hash&gt;-v&lt;version&gt; and push it to the remote repository. This can only be done on the **main** or **master** branch.
+Creating a release without a commit is now the default behaviour, and in a future version will become the only way to make releases. It is recommended that you migrate your workflow as soon as possible to releasing without a commit.
+
+Releasing creates a Git tag in the format `YYYYmonDD-HHMM-<short_commit_hash>-v<version>`, where `<short_commit_hash>` is the first seven characters of the hash of the latest commit on the main branch, and `<version>` is one more than the `<version>` in the previous release tag. The tag is pushed to the remote repository. Releasing can only be done on the `main` or `master` branch.
 
 ```bash
 $ ed release
 ```
 
-Optional flag to deploy to the given environment(s) after creating the release. Shorthand -d.
+To revert back to the previous behaviour of creating a release with a commit, set `EpiDeploy.create_release_commit` to `true` in your `config/epi_deploy.rb`. This raises a deprecation warning each time a release is made.
+
+```rb
+# config/epi_deploy.rb
+EpiDeploy.create_release_commit = true
+```
+
+Creating a release with a commit creates or bumps the version in `config/initializers/version.rb`, setting an `APP_VERSION` constant. This is read instead of the latest release tag when determining what `<version>` to use.
+
+```rb
+# config/initializers/version.rb
+APP_VERSION = '2'
+```
+
+The change is committed, and pushed up. The `<short_commit_hash>` is the hash of the parent of the release commit, **not** the release commit itself.
+
+By default, creating a release is prevented if your working tree or index is dirty, i.e. you have changes to files that are already tracked by Git, or you have staged any changes. To ignore this, you can pass the `--allow-dirty` flag when releasing
+
+```rb
+ed release --allow-dirty
+```
+
+If `EpiDeploy.create_release_commit = true`, then this will call `git reset` to unstage any staged changes to ensure that only the change to the `version.rb` is committed.
+
+### Deploying a release
+
+The simplest way to deploy is at the same time as creating a commit, by passing the `--deploy` or `-d` flag with the given environment(s) after creating the release. Separate each environment with a colon.
 
 ```bash
 $ ed release --deploy demo:production
 ```
 
-Deploy the latest release to the given environment(s).
+Alternatively, you can deploy separately to creating a release using the `deploy` command. This deploys the latest release to the given environment(s) by default. Separate each environment with a space.
 
 ```bash
 $ ed deploy demo production
 ```
 
-Optional flag to specify which tag, commit, or branch to deploy to the given environment(s). Shorthand -r. If the flag is provided without a reference you will be prompted to choose from the latest releases.
+You can also pass the `--ref` or `-r` flag to specify which tag, commit, or branch to deploy to the given environment(s). If the flag is provided without a reference you will be prompted to choose from the latest releases.
 
 ```bash
 $ ed deploy demo production --ref <reference>

--- a/README.md
+++ b/README.md
@@ -77,10 +77,11 @@ The simplest way to deploy is at the same time as creating a commit, by passing 
 $ ed release --deploy demo:production
 ```
 
-Alternatively, you can deploy separately to creating a release using the `deploy` command. This deploys the latest release to the given environment(s) by default. Separate each environment with a space.
+Alternatively, you can release and deploy separately, by using the `deploy` command to deploy. This deploys the latest release to the given environment(s) by default. Separate each environment with a space.
 
 ```bash
-$ ed deploy demo production
+ed release
+ed deploy demo production
 ```
 
 You can also pass the `--ref` or `-r` flag to specify which tag, commit, or branch to deploy to the given environment(s). If the flag is provided without a reference you will be prompted to choose from the latest releases.

--- a/lib/epi_deploy/app_version.rb
+++ b/lib/epi_deploy/app_version.rb
@@ -37,11 +37,11 @@ module EpiDeploy
       app_version
     end
 
-    private
-
     def version_file_exists?
       File.exist? version_file_path
     end
+
+    private
 
     def extract_version_number(contents)
       contents.match(/APP_VERSION\s*=\s*'(?<version>\d+).*'/)[:version].to_i

--- a/lib/epi_deploy/cli.rb
+++ b/lib/epi_deploy/cli.rb
@@ -16,6 +16,7 @@ module EpiDeploy
           description "Create a new release with optional deploy"
 
           on :d=, :deploy=, "Deploy to specified environment(s)", argument: :optional, as: Array, delimiter: ":"
+          on :allow_dirty, "Allow creating a release with a dirty working tree or index", default: false
 
           run do |options, args|
             command = EpiDeploy::Command.new(options, args)

--- a/lib/epi_deploy/command.rb
+++ b/lib/epi_deploy/command.rb
@@ -52,7 +52,7 @@ module EpiDeploy
       print_notice "Select a recent release (or just press enter for latest):"
 
       tag_list = {}
-      self.release_class.new.release_tags_list.each_with_index do |release, i|
+      GitWrapper.new.release_tag_list.each_with_index do |release, i|
         number = i + 1
         tag_list[number.to_s] = release
         print_notice "#{number}: #{release}"

--- a/lib/epi_deploy/command.rb
+++ b/lib/epi_deploy/command.rb
@@ -21,7 +21,7 @@ module EpiDeploy
 
     def release
       release = self.release_class.new
-      if release.create!
+      if release.create!(allow_dirty:)
         print_success "Release #{release.version} created with tag #{release.tag}"
       else
         print_notice "Release #{release.version} has already been created on the most recent commit"
@@ -89,6 +89,10 @@ module EpiDeploy
 
     def stages_extractor
       @stages_extractor ||= StagesExtractor.new
+    end
+
+    def allow_dirty
+      options[:allow_dirty]
     end
 
   end

--- a/lib/epi_deploy/config.rb
+++ b/lib/epi_deploy/config.rb
@@ -15,7 +15,7 @@ module EpiDeploy
     attr_reader :create_release_commit
 
     def use_tags_for_deploy=(use_tags_for_deploy)
-      print_warning "[Deprecation Warning] The use_tags_for_deploy option is now obsolete. Remove this from your configuration."
+      print_failure_and_abort "The use_tags_for_deploy option is now obsolete. Remove this from your configuration to continue."
       @use_tags_for_deploy = use_tags_for_deploy
     end
 

--- a/lib/epi_deploy/config.rb
+++ b/lib/epi_deploy/config.rb
@@ -12,7 +12,7 @@ module EpiDeploy
 
     attr_reader :use_tags_for_deploy
     attr_accessor :use_timestamped_deploy_tags
-    attr_writer :create_release_commit
+    attr_accessor :create_release_commit
 
     def use_tags_for_deploy=(use_tags_for_deploy)
       print_warning "[Deprecation Warning] The use_tags_for_deploy option is now obsolete. Remove this from your configuration."
@@ -20,7 +20,15 @@ module EpiDeploy
     end
 
     def create_release_commit?
-      @create_release_commit
+      create_release_commit
+    end
+
+    def use_tags_for_deploy?
+      use_tags_for_deploy
+    end
+
+    def use_timestamped_deploy_tags?
+      use_timestamped_deploy_tags
     end
 
   end

--- a/lib/epi_deploy/config.rb
+++ b/lib/epi_deploy/config.rb
@@ -2,7 +2,7 @@ require_relative "helpers"
 
 module EpiDeploy
 
-  include Helpers
+  extend Helpers
 
   @use_tags_for_deploy = false
   @use_timestamped_deploy_tags = false
@@ -12,11 +12,24 @@ module EpiDeploy
 
     attr_reader :use_tags_for_deploy
     attr_accessor :use_timestamped_deploy_tags
-    attr_accessor :create_release_commit
+    attr_reader :create_release_commit
 
     def use_tags_for_deploy=(use_tags_for_deploy)
       print_warning "[Deprecation Warning] The use_tags_for_deploy option is now obsolete. Remove this from your configuration."
       @use_tags_for_deploy = use_tags_for_deploy
+    end
+
+    def create_release_commit=(value)
+      if value
+        print_warning <<~EOF.chomp
+          [Deprecation Warning] The create_release_commit option should only be used
+          if it is currently necessary for your workflow.
+
+          Please migrate to releasing without a commit, as releasing with a commit
+          will be removed in a future version. Instructions can be found in the README.
+        EOF
+      end
+      @create_release_commit = value
     end
 
     def create_release_commit?

--- a/lib/epi_deploy/config.rb
+++ b/lib/epi_deploy/config.rb
@@ -15,7 +15,11 @@ module EpiDeploy
     attr_reader :create_release_commit
 
     def use_tags_for_deploy=(use_tags_for_deploy)
-      print_failure_and_abort "The use_tags_for_deploy option is now obsolete. Remove this from your configuration to continue."
+      print_failure_and_abort <<~EOF.chomp
+        The use_tags_for_deploy option is now obsolete. It has been superseded by use_timestamped_deploy_tags.
+        See the section on branchless deployments in the README.
+        https://github.com/epigenesys/epi_deploy/blob/master/README.md
+      EOF
       @use_tags_for_deploy = use_tags_for_deploy
     end
 
@@ -25,8 +29,9 @@ module EpiDeploy
           [Deprecation Warning] The create_release_commit option should only be used
           if it is currently necessary for your workflow.
 
-          Please migrate to releasing without a commit, as releasing with a commit
-          will be removed in a future version. Instructions can be found in the README.
+          Please migrate to commitless releases, as commitful releases will be removed
+          in a future version. Instructions can be found in the README.
+          https://github.com/epigenesys/epi_deploy/blob/master/README.md
         EOF
       end
       @create_release_commit = value

--- a/lib/epi_deploy/config.rb
+++ b/lib/epi_deploy/config.rb
@@ -1,4 +1,8 @@
+require_relative "helpers"
+
 module EpiDeploy
+
+  include Helpers
 
   @use_tags_for_deploy = false
   @use_timestamped_deploy_tags = false
@@ -11,7 +15,7 @@ module EpiDeploy
     attr_writer :create_release_commit
 
     def use_tags_for_deploy=(use_tags_for_deploy)
-      warn "[Deprecation Warning] The use_tags_for_deploy option is now obsolete. Remove this from your configuration."
+      print_warning "[Deprecation Warning] The use_tags_for_deploy option is now obsolete. Remove this from your configuration."
       @use_tags_for_deploy = use_tags_for_deploy
     end
 

--- a/lib/epi_deploy/config.rb
+++ b/lib/epi_deploy/config.rb
@@ -2,15 +2,21 @@ module EpiDeploy
 
   @use_tags_for_deploy = false
   @use_timestamped_deploy_tags = false
+  @create_release_commit = false
 
   class << self
 
     attr_reader :use_tags_for_deploy
     attr_accessor :use_timestamped_deploy_tags
+    attr_writer :create_release_commit
 
     def use_tags_for_deploy=(use_tags_for_deploy)
       warn "[Deprecation Warning] The use_tags_for_deploy option is now obsolete. Remove this from your configuration."
       @use_tags_for_deploy = use_tags_for_deploy
+    end
+
+    def create_release_commit?
+      @create_release_commit
     end
 
   end

--- a/lib/epi_deploy/deployer.rb
+++ b/lib/epi_deploy/deployer.rb
@@ -21,6 +21,11 @@ module EpiDeploy
         if EpiDeploy.use_timestamped_deploy_tags
           deploy_with_timestamped_tags(stages_or_environments)
         else
+          print_warning <<~EOF
+            [Deprecation Warning] Deploying with tags will be the only option
+            in the next major release, and deploying with branches will be removed.
+            Refer to the README on GitLab for instructions on how to switch to using tags.
+          EOF
           deploy_with_environment_branches(stages_or_environments)
         end
       rescue ::Git::GitExecuteError => e

--- a/lib/epi_deploy/deployer.rb
+++ b/lib/epi_deploy/deployer.rb
@@ -22,9 +22,10 @@ module EpiDeploy
           deploy_with_timestamped_tags(stages_or_environments)
         else
           print_warning <<~EOF.chomp
-            [Deprecation Warning] Deploying with tags will be the only option
-            in the next major release, and deploying with branches will be removed.
-            Refer to the README on GitLab for instructions on how to switch to using tags.
+            [Deprecation Warning] Branchless deployments will be the only option
+            in a future version, and branchful deployments will be removed.
+            See the section on branchless deployments in the README for instructions.
+            https://github.com/epigenesys/epi_deploy/blob/master/README.md
           EOF
           deploy_with_environment_branches(stages_or_environments)
         end

--- a/lib/epi_deploy/deployer.rb
+++ b/lib/epi_deploy/deployer.rb
@@ -21,7 +21,7 @@ module EpiDeploy
         if EpiDeploy.use_timestamped_deploy_tags
           deploy_with_timestamped_tags(stages_or_environments)
         else
-          print_warning <<~EOF
+          print_warning <<~EOF.chomp
             [Deprecation Warning] Deploying with tags will be the only option
             in the next major release, and deploying with branches will be removed.
             Refer to the README on GitLab for instructions on how to switch to using tags.

--- a/lib/epi_deploy/git_wrapper.rb
+++ b/lib/epi_deploy/git_wrapper.rb
@@ -5,6 +5,12 @@ module EpiDeploy
   class GitWrapper
 
     include EpiDeploy::Helpers
+    attr_writer :git
+
+    def initialize(git: nil)
+      self.git = git
+    end
+
     def on_primary_branch?
       ["main", "master"].include? current_branch
     end
@@ -66,9 +72,16 @@ module EpiDeploy
     end
 
     def delete_branches(branches)
-      remote_refs = branches.map { |branch| "refs/heads/#{branch}" }
-      run_custom_command("git push origin #{remote_refs.join(' ')} --delete")
-      local_branches(branches).each(&:delete)
+      # Delete remote branches
+      remote_branches = filter_branches(git.branches.remote, branches)
+      if remote_branches.any?
+        remote_refs = remote_branches.map { |branch| "refs/heads/#{branch.name}" }
+        run_custom_command("git push origin #{remote_refs.join(' ')} --delete")
+      end
+
+      # Delete local branches
+      local_branches = filter_branches(git.branches.local, branches)
+      local_branches.each(&:delete)
     end
 
     # Returns a list of all annotated tags sorted by the date which the tag was created, newest first
@@ -106,9 +119,8 @@ module EpiDeploy
       run_custom_command("git branch -f #{name} #{commit}")
     end
 
-    def local_branches(branch_names = [])
-      branches = git.branches.local.filter { |branch| branch_names.include? branch.name }
-      branches || []
+    def filter_branches(branches, names = [])
+      branches.filter { |branch| names.include? branch.name }
     end
 
     def run_custom_command(command)

--- a/lib/epi_deploy/git_wrapper.rb
+++ b/lib/epi_deploy/git_wrapper.rb
@@ -66,7 +66,7 @@ module EpiDeploy
     end
 
     def release_tag_list
-      @release_tag_list ||= tag_list.filter { |tag| tag.match? Release::RELEASE_TAG_REGEX }
+      @release_tag_list ||= tag_list.filter { |tag| tag.match? ReleaseTag::REGEXP }
     end
 
     def most_recent_release_tag

--- a/lib/epi_deploy/git_wrapper.rb
+++ b/lib/epi_deploy/git_wrapper.rb
@@ -21,7 +21,7 @@ module EpiDeploy
     end
 
     def commit(message)
-      git.commit_all message
+      git.commit message
     end
 
     def push(branch, **options)

--- a/lib/epi_deploy/git_wrapper.rb
+++ b/lib/epi_deploy/git_wrapper.rb
@@ -60,8 +60,17 @@ module EpiDeploy
       local_branches(branches).each(&:delete)
     end
 
+    # Returns a list of all annotated tags sorted by the date which the tag was created, newest first
     def tag_list
-      @tag_list ||= `git for-each-ref --sort=taggerdate --format '%(tag)' refs/tags`.gsub("'", "").split.reverse
+      @tag_list ||= `git tag --list --sort=taggerdate --format='%(tag)'`.split.reverse
+    end
+
+    def release_tag_list
+      @release_tag_list ||= tag_list.filter { |tag| tag.match? Release::RELEASE_TAG_REGEX }
+    end
+
+    def most_recent_release_tag
+      release_tag_list.first
     end
 
     def current_branch

--- a/lib/epi_deploy/git_wrapper.rb
+++ b/lib/epi_deploy/git_wrapper.rb
@@ -10,10 +10,17 @@ module EpiDeploy
     end
 
     def pending_changes?
-      # replaced the git library with a system call
-      # due to it iterating all project files when
-      # doing a git status.
-      !system("git diff --quiet --exit-code")
+      !working_tree_clean? || !stage_clean?
+    end
+
+    # git library is not used here as #status iterates over all project files
+    # which is not performant for large projects.
+    def working_tree_clean?
+      system "git diff --quiet --exit-code"
+    end
+
+    def stage_clean?
+      system "git diff --cached --quiet --exit-code"
     end
 
     def pull

--- a/lib/epi_deploy/git_wrapper.rb
+++ b/lib/epi_deploy/git_wrapper.rb
@@ -24,6 +24,10 @@ module EpiDeploy
       git.commit message
     end
 
+    def reset(...)
+      git.reset(...)
+    end
+
     def push(branch, **options)
       options = { force: false, tags: true }.merge(options)
       git.push "origin", branch, **options

--- a/lib/epi_deploy/helpers.rb
+++ b/lib/epi_deploy/helpers.rb
@@ -11,7 +11,7 @@ module EpiDeploy
     end
 
     def print_warning(message)
-      $stdout.puts "#{COLOUR_YELLOW}#{message}#{COLOUR_RESET}"
+      Kernel.warn "#{COLOUR_YELLOW}#{message}#{COLOUR_RESET}"
     end
 
     def print_success(message)

--- a/lib/epi_deploy/helpers.rb
+++ b/lib/epi_deploy/helpers.rb
@@ -3,10 +3,15 @@ module EpiDeploy
 
     COLOUR_RED    = "\x1B[31m"
     COLOUR_GREEN  = "\x1B[32m"
+    COLOUR_YELLOW = "\x1B[33m"
     COLOUR_RESET  = "\x1B[0m"
 
     def print_notice(message)
       $stdout.puts message
+    end
+
+    def print_warning(message)
+      $stdout.puts "#{COLOUR_YELLOW}#{message}#{COLOUR_RESET}"
     end
 
     def print_success(message)

--- a/lib/epi_deploy/release.rb
+++ b/lib/epi_deploy/release.rb
@@ -31,6 +31,7 @@ module EpiDeploy
       if EpiDeploy.create_release_commit?
         create_with_commit!
       else
+        print_warning "The file config/initializers/version.rb can be deleted as it is no longer needed" if app_version.version_file_exists?
         create_without_commit!
       end
     end

--- a/lib/epi_deploy/release.rb
+++ b/lib/epi_deploy/release.rb
@@ -83,8 +83,26 @@ module EpiDeploy
     def create_without_commit!
       common_steps
 
-      false if most_recent_commit_already_tagged?
+      result = false
+      release_tag = nil
 
+      if release_tag_list.empty?
+        release_tag = ReleaseTag.new commit: git_wrapper.short_commit_hash, version: 1
+      elsif most_recent_commit_already_tagged?
+        self.app_version.version = most_recent_release_tag.version
+      else
+        release_tag = most_recent_release_tag.increment(commit: git_wrapper.short_commit_hash)
+      end
+
+      unless release_tag.nil?
+        self.tag = "#{release_tag}"
+        git_wrapper.create_or_update_tag(self.tag)
+        self.app_version.version = release_tag.version
+
+        result = true
+      end
+
+      result
     rescue ::Git::GitExecuteError => e
       print_failure_and_abort "A git error occurred: #{e.message}"
     end
@@ -104,7 +122,11 @@ module EpiDeploy
     end
 
     def most_recent_commit_already_tagged?
-      git_wrapper.git_object_for(git_wrapper.most_recent_release_tag) == git_wrapper.most_recent_commit
+      git_wrapper.git_object_for("#{most_recent_release_tag}").sha == git_wrapper.most_recent_commit.sha
+    end
+
+    def most_recent_release_tag
+      @most_recent_release_tag ||= ReleaseTag.parse(git_wrapper.most_recent_release_tag)
     end
 
     def get_commit(git_reference)

--- a/lib/epi_deploy/release.rb
+++ b/lib/epi_deploy/release.rb
@@ -27,7 +27,9 @@ module EpiDeploy
       self.app_version = app_version
     end
 
-    def create!
+    def create!(allow_dirty: false)
+      @allow_dirty = allow_dirty
+
       if EpiDeploy.create_release_commit?
         create_with_commit!
       else
@@ -115,8 +117,19 @@ module EpiDeploy
     end
 
     def prerelease_checks
-      print_failure_and_abort "You can only create a release on the main or master branch. Please switch to main or master and try again." unless git_wrapper.on_primary_branch?
-      print_failure_and_abort "You have pending changes, please commit or stash them and try again." if git_wrapper.pending_changes?
+      messages = []
+      unless git_wrapper.on_primary_branch?
+        messages << "You can only create a release on the main or master branch - please switch to main or master."
+      end
+
+      if git_wrapper.pending_changes? && !@allow_dirty
+        messages << "You have pending changes - please commit or stash them, or pass the --allow-dirty flag."
+      end
+
+      unless messages.empty?
+        messages.unshift "There were one or more errors with creating a release:"
+        print_failure_and_abort messages.join("\n")
+      end
     end
 
     def app_version

--- a/lib/epi_deploy/release.rb
+++ b/lib/epi_deploy/release.rb
@@ -3,6 +3,7 @@ require "git"
 require_relative "helpers"
 require_relative "git_wrapper"
 require_relative "app_version"
+require_relative "config"
 
 module EpiDeploy
   class Release
@@ -11,9 +12,54 @@ module EpiDeploy
 
     MONTHS = %w[jan feb mar apr may jun jul aug sep oct nov dec]
 
-    attr_accessor :reference, :tag, :commit
+    attr_accessor :reference
+    attr_accessor :tag
+    attr_accessor :commit
+    attr_writer :git_wrapper
+    attr_writer :app_version
+
+    def initialize(reference: nil, tag: nil, commit: nil, git_wrapper: nil, app_version: nil)
+      self.reference = reference
+      self.tag = tag
+      self.commit = commit
+      self.git_wrapper = git_wrapper
+      self.app_version = app_version
+    end
 
     def create!
+      if EpiDeploy.create_release_commit?
+        create_with_commit!
+      else
+        raise "Not implemented"
+      end
+    end
+
+    def version
+      app_version.version
+    end
+
+    def release_tags_list
+      git_wrapper.tag_list.filter do |tag|
+        tag.match?(/\A\d{4}[a-z]{3}\d{2}-\d{4}-[0-9a-f]+-v\d+\z/)
+      end
+    end
+
+    def git_wrapper
+      @git_wrapper ||= GitWrapper.new
+    end
+
+    def self.find(reference)
+      release = self.new
+      commit = release.send(:get_commit, reference)
+      print_failure_and_abort("Cannot find commit for reference '#{reference}'") if commit.nil?
+      release.commit = commit
+      release.reference = reference
+      release
+    end
+
+    private
+
+    def create_with_commit!
       return print_failure_and_abort "You can only create a release on the main or master branch. Please switch to main or master and try again." unless git_wrapper.on_primary_branch?
       return print_failure_and_abort "You have pending changes, please commit or stash them and try again."  if git_wrapper.pending_changes?
 
@@ -40,33 +86,8 @@ module EpiDeploy
       end
     end
 
-    def version
-      app_version.version
-    end
-
-    def release_tags_list
-      git_wrapper.tag_list.filter do |tag|
-        tag.match?(/\A\d{4}[a-z]{3}\d{2}-\d{4}-[0-9a-f]+-v\d+\z/)
-      end
-    end
-
-    def git_wrapper(klass = EpiDeploy::GitWrapper)
-      @git_wrapper ||= klass.new
-    end
-
-    def self.find(reference)
-      release = self.new
-      commit = release.send(:get_commit, reference)
-      print_failure_and_abort("Cannot find commit for reference '#{reference}'") if commit.nil?
-      release.commit = commit
-      release.reference = reference
-      release
-    end
-
-    private
-
-    def app_version(app_version_class = EpiDeploy::AppVersion)
-      @app_version ||= app_version_class.open
+    def app_version
+      @app_version ||= AppVersion.open
     end
 
     # Use Time.zone if we have it (i.e. Rails), otherwise use Time

--- a/lib/epi_deploy/release.rb
+++ b/lib/epi_deploy/release.rb
@@ -11,8 +11,6 @@ module EpiDeploy
 
     include EpiDeploy::Helpers
 
-    MONTHS = %w[jan feb mar apr may jun jul aug sep oct nov dec]
-
     attr_accessor :reference
     attr_accessor :tag
     attr_accessor :commit
@@ -33,7 +31,10 @@ module EpiDeploy
       if EpiDeploy.create_release_commit?
         create_with_commit!
       else
-        print_warning "The file config/initializers/version.rb can be deleted as it is no longer needed" if app_version.version_file_exists?
+        print_warning <<~EOF.chomp if app_version.version_file_exists?
+          The file config/initializers/version.rb should be deleted as it is no longer needed by epi_deploy
+          Run 'git rm config/initializers/version.rb' to remove and stage the removal.
+        EOF
         create_without_commit!
       end
     end
@@ -62,13 +63,13 @@ module EpiDeploy
     private
 
     def create_with_commit!
-      common_steps
+      prerelease_steps
 
       if git_wrapper.most_recent_commit.message.start_with? "Bumped to version"
         false
       else
         new_version = app_version.bump
-        self.tag = ReleaseTag.new(commit: git_wrapper.short_commit_hash, version: new_version).to_s
+        self.tag = ReleaseTag.new(commit: git_wrapper.short_commit_hash, version: new_version).name
         app_version.latest_release_tag = self.tag
         app_version.save!
         git_wrapper.reset
@@ -85,7 +86,7 @@ module EpiDeploy
     end
 
     def create_without_commit!
-      common_steps
+      prerelease_steps
 
       result = false
       release_tag = nil
@@ -99,7 +100,7 @@ module EpiDeploy
       end
 
       unless release_tag.nil?
-        self.tag = "#{release_tag}"
+        self.tag = release_tag.name
         git_wrapper.create_or_update_tag(self.tag)
         self.app_version.version = release_tag.version
 
@@ -111,7 +112,7 @@ module EpiDeploy
       print_failure_and_abort "A git error occurred: #{e.message}"
     end
 
-    def common_steps
+    def prerelease_steps
       prerelease_checks
       git_wrapper.pull
     end

--- a/lib/epi_deploy/release.rb
+++ b/lib/epi_deploy/release.rb
@@ -4,6 +4,7 @@ require_relative "helpers"
 require_relative "git_wrapper"
 require_relative "app_version"
 require_relative "config"
+require_relative "release_tag"
 
 module EpiDeploy
   class Release
@@ -11,7 +12,6 @@ module EpiDeploy
     include EpiDeploy::Helpers
 
     MONTHS = %w[jan feb mar apr may jun jul aug sep oct nov dec]
-    RELEASE_TAG_REGEX = /\A\d{4}[a-z]{3}\d{2}-\d{4}-[0-9a-f]+-v\d+\z/
 
     attr_accessor :reference
     attr_accessor :tag
@@ -65,7 +65,7 @@ module EpiDeploy
         false
       else
         new_version = app_version.bump
-        self.tag = "#{date_and_time_for_tag}-#{git_wrapper.short_commit_hash}-v#{new_version}"
+        self.tag = ReleaseTag.new(commit: git_wrapper.short_commit_hash, version: new_version).to_s
         app_version.latest_release_tag = self.tag
         app_version.save!
         git_wrapper.add(app_version.version_file_path)
@@ -105,12 +105,6 @@ module EpiDeploy
 
     def most_recent_commit_already_tagged?
       git_wrapper.git_object_for(git_wrapper.most_recent_release_tag) == git_wrapper.most_recent_commit
-    end
-
-    # Use Time.zone if we have it (i.e. Rails), otherwise use Time
-    def date_and_time_for_tag(time_class = (Time.respond_to?(:zone) ? Time.zone : Time))
-      time = time_class.now
-      time.strftime "%Y#{MONTHS[time.month - 1]}%d-%H%M"
     end
 
     def get_commit(git_reference)

--- a/lib/epi_deploy/release.rb
+++ b/lib/epi_deploy/release.rb
@@ -11,6 +11,7 @@ module EpiDeploy
     include EpiDeploy::Helpers
 
     MONTHS = %w[jan feb mar apr may jun jul aug sep oct nov dec]
+    RELEASE_TAG_REGEX = /\A\d{4}[a-z]{3}\d{2}-\d{4}-[0-9a-f]+-v\d+\z/
 
     attr_accessor :reference
     attr_accessor :tag
@@ -30,7 +31,7 @@ module EpiDeploy
       if EpiDeploy.create_release_commit?
         create_with_commit!
       else
-        raise "Not implemented"
+        create_without_commit!
       end
     end
 
@@ -38,10 +39,8 @@ module EpiDeploy
       app_version.version
     end
 
-    def release_tags_list
-      git_wrapper.tag_list.filter do |tag|
-        tag.match?(/\A\d{4}[a-z]{3}\d{2}-\d{4}-[0-9a-f]+-v\d+\z/)
-      end
+    def release_tag_list
+      git_wrapper.release_tag_list
     end
 
     def git_wrapper
@@ -60,34 +59,52 @@ module EpiDeploy
     private
 
     def create_with_commit!
-      return print_failure_and_abort "You can only create a release on the main or master branch. Please switch to main or master and try again." unless git_wrapper.on_primary_branch?
-      return print_failure_and_abort "You have pending changes, please commit or stash them and try again."  if git_wrapper.pending_changes?
+      common_steps
 
-      begin
-        git_wrapper.pull
+      if git_wrapper.most_recent_commit.message.start_with? "Bumped to version"
+        false
+      else
+        new_version = app_version.bump
+        self.tag = "#{date_and_time_for_tag}-#{git_wrapper.short_commit_hash}-v#{new_version}"
+        app_version.latest_release_tag = self.tag
+        app_version.save!
+        git_wrapper.add(app_version.version_file_path)
+        git_wrapper.commit "Bumped to version #{new_version} [skip ci]"
 
-        if git_wrapper.most_recent_commit.message.start_with? "Bumped to version"
-          false
-        else
-          new_version = app_version.bump
-          self.tag = "#{date_and_time_for_tag}-#{git_wrapper.short_commit_hash}-v#{new_version}"
-          app_version.latest_release_tag = self.tag
-          app_version.save!
-          git_wrapper.add(app_version.version_file_path)
-          git_wrapper.commit "Bumped to version #{new_version} [skip ci]"
+        git_wrapper.create_or_update_tag(self.tag, push: false)
+        git_wrapper.push(git_wrapper.current_branch, tags: true)
 
-          git_wrapper.create_or_update_tag(self.tag, push: false)
-          git_wrapper.push(git_wrapper.current_branch, tags: true)
-
-          true
-        end
-      rescue ::Git::GitExecuteError => e
-        print_failure_and_abort "A git error occurred: #{e.message}"
+        true
       end
+    rescue ::Git::GitExecuteError => e
+      print_failure_and_abort "A git error occurred: #{e.message}"
+    end
+
+    def create_without_commit!
+      common_steps
+
+      false if most_recent_commit_already_tagged?
+
+    rescue ::Git::GitExecuteError => e
+      print_failure_and_abort "A git error occurred: #{e.message}"
+    end
+
+    def common_steps
+      prerelease_checks
+      git_wrapper.pull
+    end
+
+    def prerelease_checks
+      print_failure_and_abort "You can only create a release on the main or master branch. Please switch to main or master and try again." unless git_wrapper.on_primary_branch?
+      print_failure_and_abort "You have pending changes, please commit or stash them and try again." if git_wrapper.pending_changes?
     end
 
     def app_version
       @app_version ||= AppVersion.open
+    end
+
+    def most_recent_commit_already_tagged?
+      git_wrapper.git_object_for(git_wrapper.most_recent_release_tag) == git_wrapper.most_recent_commit
     end
 
     # Use Time.zone if we have it (i.e. Rails), otherwise use Time
@@ -98,8 +115,8 @@ module EpiDeploy
 
     def get_commit(git_reference)
       if git_reference == :latest
-        print_failure_and_abort("There is no latest release. Create one, or specify a reference with --ref") if self.release_tags_list.empty?
-        git_reference = release_tags_list.first
+        git_reference = git_wrapper.most_recent_release_tag
+        print_failure_and_abort("There is no latest release. Create one, or specify a reference with --ref") if git_reference.nil?
       end
 
       git_wrapper.git_object_for(git_reference)

--- a/lib/epi_deploy/release.rb
+++ b/lib/epi_deploy/release.rb
@@ -69,6 +69,7 @@ module EpiDeploy
         self.tag = ReleaseTag.new(commit: git_wrapper.short_commit_hash, version: new_version).to_s
         app_version.latest_release_tag = self.tag
         app_version.save!
+        git_wrapper.reset
         git_wrapper.add(app_version.version_file_path)
         git_wrapper.commit "Bumped to version #{new_version} [skip ci]"
 

--- a/lib/epi_deploy/release_tag.rb
+++ b/lib/epi_deploy/release_tag.rb
@@ -36,8 +36,12 @@ module EpiDeploy
       self.class.new timestamp:, commit:, version: version + 1
     end
 
-    def to_s
+    def name
       "#{dump_timestamp(timestamp)}-#{commit}-v#{version}"
+    end
+
+    def to_s
+      name
     end
 
     private

--- a/lib/epi_deploy/release_tag.rb
+++ b/lib/epi_deploy/release_tag.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+require "time"
+
+module EpiDeploy
+  class ReleaseTag
+
+    attr_reader :timestamp
+    attr_accessor :commit
+    attr_accessor :version
+
+    REGEXP = /\A(?<timestamp>\d{4}[a-z]{3}\d{2}-\d{4})-(?<commit>[0-9a-f]+)-v(?<version>\d+)\z/
+    TIMESTAMP_FORMAT = "%Y%b%d-%H%M"
+
+    def initialize(timestamp: nil, commit:, version:)
+      timestamp ||= time_class.now
+
+      self.timestamp = timestamp
+      self.commit = commit
+      self.version = version.to_i
+    end
+
+    def self.parse(string)
+      match = REGEXP.match(string)
+      return nil if match.nil?
+
+      kwargs = match.named_captures.to_h { |k, v| [k.to_sym, v] }
+      new(**kwargs)
+    end
+
+    def timestamp=(timestamp)
+      @timestamp = parse_timestamp(timestamp)
+    end
+
+    def increment(timestamp: nil, commit:)
+      self.class.new timestamp:, commit:, version: version + 1
+    end
+
+    def to_s
+      "#{dump_timestamp(timestamp)}-#{commit}-v#{version}"
+    end
+
+    private
+
+    def dump_timestamp(timestamp)
+      timestamp.strftime(TIMESTAMP_FORMAT).downcase
+    end
+
+    def parse_timestamp(timestamp)
+      if timestamp.is_a? String
+        time_class.strptime timestamp, TIMESTAMP_FORMAT
+      else
+        timestamp
+      end
+    end
+
+    # Use Time.zone if we have it (i.e. Rails), otherwise use Time
+    def time_class
+      if Time.respond_to? :zone
+        Time.zone
+      else
+        Time
+      end
+    end
+
+  end
+end

--- a/spec/features/deploy_spec.rb
+++ b/spec/features/deploy_spec.rb
@@ -62,7 +62,7 @@ describe "Deploy", :bundle, type: :aruba do
     specify "it exits with an error" do
       run_ed "deploy production"
 
-      expect(all_output).to include "The use_tags_for_deploy option is now obsolete. Remove this from your configuration to continue."
+      expect(all_output).to include "The use_tags_for_deploy option is now obsolete. It has been superseded by use_timestamped_deploy_tags."
     end
   end
 end

--- a/spec/features/deploy_spec.rb
+++ b/spec/features/deploy_spec.rb
@@ -17,11 +17,20 @@ describe "Deploy", :bundle, type: :aruba do
   end
 
   it "deploys latest release" do
-    run_command_and_stop 'git tag -a example_tag -m "For testing"'  # Create a pretend release
+    run_command_and_stop 'git tag -a 2026jun09-1610-c17fe6f-v1 -m "For testing"'  # Create a pretend release
     run_command_and_stop 'git push'
 
-    run_ed 'deploy production -r example_tag'
+    run_ed 'deploy production'
 
+    expect(all_output).to include('Deploying to production...')
+    expect(last_command_started).to have_exit_status(0)
+  end
+
+  it "deploys the reference specified" do
+    run_command_and_stop 'git tag -a feature-tag -m "For testing"'
+    run_command_and_stop "git push"
+
+    run_ed "deploy production -r feature-tag"
     expect(all_output).to include('Deploying to production...')
     expect(last_command_started).to have_exit_status(0)
   end

--- a/spec/features/deploy_spec.rb
+++ b/spec/features/deploy_spec.rb
@@ -25,4 +25,21 @@ describe "Deploy", :bundle, type: :aruba do
     expect(all_output).to include('Deploying to production...')
     expect(last_command_started).to have_exit_status(0)
   end
+
+  context "given that EpiDeploy.use_timestamped_deploy_tags is configured to false" do
+    before do
+      write_file "config/epi_deploy.rb", <<~RUBY
+        EpiDeploy.use_timestamped_deploy_tags = false
+      RUBY
+    end
+
+    specify "it prints a deprecation warning that prompts me to switch to using tags" do
+      run_command_and_stop 'git tag -a 2026jun09-1610-c17fe6f-v1 -m "For testing"'  # Create a pretend release
+      run_command_and_stop 'git push'
+
+      run_ed "deploy production"
+
+      expect(all_output).to include "[Deprecation Warning] Deploying with tags will be the only option"
+    end
+  end
 end

--- a/spec/features/deploy_spec.rb
+++ b/spec/features/deploy_spec.rb
@@ -48,7 +48,7 @@ describe "Deploy", :bundle, type: :aruba do
 
       run_ed "deploy production"
 
-      expect(all_output).to include "[Deprecation Warning] Deploying with tags will be the only option"
+      expect(all_output).to include "[Deprecation Warning] Branchless deployments will be the only option"
     end
   end
 

--- a/spec/features/deploy_spec.rb
+++ b/spec/features/deploy_spec.rb
@@ -51,4 +51,18 @@ describe "Deploy", :bundle, type: :aruba do
       expect(all_output).to include "[Deprecation Warning] Deploying with tags will be the only option"
     end
   end
+
+  context "given that EpiDeploy.use_tags_for_deploy is configured" do
+    before do
+      write_file "config/epi_deploy.rb", <<~RUBY
+        EpiDeploy.use_tags_for_deploy = true
+      RUBY
+    end
+
+    specify "it exits with an error" do
+      run_ed "deploy production"
+
+      expect(all_output).to include "The use_tags_for_deploy option is now obsolete. Remove this from your configuration to continue."
+    end
+  end
 end

--- a/spec/features/release_spec.rb
+++ b/spec/features/release_spec.rb
@@ -1,7 +1,14 @@
 require 'spec_helper'
 require 'support/aruba_helper'
 
+require "git"
+
 describe "Release", :bundle, type: :aruba do
+  let(:git) { Git.open(aruba.config.home_directory) }
+  let(:short_commit_hash) { git.log[1].sha[0..6] }
+  let(:expected_version) {}
+  let(:expected_release_tag) { "#{Time.now.strftime("%Y%b%d-%H%M")}-#{short_commit_hash}-v#{expected_version}".downcase }
+
   context "given EpiDeploy.create_release_commit option is configured to true" do
     before do
       write_file "config/epi_deploy.rb", <<~RUBY
@@ -9,12 +16,34 @@ describe "Release", :bundle, type: :aruba do
       RUBY
     end
 
-    it "creates a new release" do
-      run_ed "release"
+    context "given no version.rb is found" do
+      let(:expected_version) { 1 }
 
-      expect(last_command_started).to have_exit_status(0)
-      expect(all_output).to include("Release 1 created with tag #{Time.now.year}")
-      expect(all_output).not_to include 'Capistrano deploying to production'
+      it "creates a new release with version number 1 and does not deploy" do
+        run_ed "release"
+
+        expect(last_command_started).to have_exit_status(0)
+        expect(all_output).to include("Release #{expected_version} created with tag #{expected_release_tag}")
+        expect(all_output).not_to include 'Capistrano deploying to production'
+      end
+    end
+
+    context "given an version.rb exists with APP_VERSION set to 5" do
+      let(:expected_version) { 6 }
+
+      before do
+        write_file "config/initializers/version.rb", <<~RUBY
+          APP_VERSION = '5'
+        RUBY
+      end
+
+      it "creates a new release with version number and does not deploy" do
+        run_ed "release"
+
+        expect(last_command_started).to have_exit_status(0)
+        expect(all_output).to include("Release #{expected_version} created with tag #{expected_release_tag}")
+        expect(all_output).not_to include 'Capistrano deploying to production'
+      end
     end
 
     it "deploys the release if the flag is supplied" do

--- a/spec/features/release_spec.rb
+++ b/spec/features/release_spec.rb
@@ -5,44 +5,35 @@ require "git"
 
 describe "Release", :bundle, type: :aruba do
   let(:git) { Git.open(aruba.config.home_directory) }
-  let(:short_commit_hash) { git.log[1].sha[0..6] }
+  let(:short_commit_hash) {}
   let(:expected_version) {}
   let(:expected_release_tag) { "#{Time.now.strftime("%Y%b%d-%H%M")}-#{short_commit_hash}-v#{expected_version}".downcase }
 
-  context "given EpiDeploy.create_release_commit option is configured to true" do
-    before do
-      write_file "config/epi_deploy.rb", <<~RUBY
-        EpiDeploy.create_release_commit = true
-      RUBY
-    end
+  shared_examples "configured to not create release commit" do
+    let(:short_commit_hash) { git.log.first.sha[0..6] }
 
-    context "given no version.rb is found" do
+    context "if there are no release tags" do
       let(:expected_version) { 1 }
 
-      it "creates a new release with version number 1 and does not deploy" do
+      it "creates a new release tag with version 1 and the commit hash of the latest commit, and does not deploy" do
         run_ed "release"
 
         expect(last_command_started).to have_exit_status(0)
         expect(all_output).to include("Release #{expected_version} created with tag #{expected_release_tag}")
-        expect(all_output).not_to include 'Capistrano deploying to production'
+        expect(all_output).not_to include 'Capistrano deploying'
       end
     end
 
-    context "given an version.rb exists with APP_VERSION set to 5" do
-      let(:expected_version) { 6 }
+    context "if the most recent commit has a release tag" do
+      let(:expected_version) { 1 }
 
-      before do
-        write_file "config/initializers/version.rb", <<~RUBY
-          APP_VERSION = '5'
-        RUBY
-      end
+      before { git.add_tag expected_release_tag, annotate: true, message: expected_release_tag }
 
-      it "creates a new release with version number and does not deploy" do
+      specify "it does not create a new release tag" do
         run_ed "release"
 
         expect(last_command_started).to have_exit_status(0)
-        expect(all_output).to include("Release #{expected_version} created with tag #{expected_release_tag}")
-        expect(all_output).not_to include 'Capistrano deploying to production'
+        expect(all_output).to include("Release #{expected_version} has already been created on the most recent commit")
       end
     end
 
@@ -63,5 +54,96 @@ describe "Release", :bundle, type: :aruba do
       expect(all_output).not_to include('Deploying to production...')
       expect(all_output).not_to include 'Capistrano deploying to production'
     end
+  end
+
+  context "given EpiDeploy.create_release_commit option is configured to true" do
+    let(:short_commit_hash) { git.log[1].sha[0..6] }
+
+    before do
+      write_file "config/epi_deploy.rb", <<~RUBY
+        EpiDeploy.create_release_commit = true
+      RUBY
+    end
+
+    context "given no version.rb is found" do
+      let(:expected_version) { 1 }
+
+      it "creates a new release with version number 1 and the commit hash of the previous commit, and does not deploy" do
+        run_ed "release"
+
+        expect(last_command_started).to have_exit_status(0)
+        expect(all_output).to include("Release #{expected_version} created with tag #{expected_release_tag}")
+        expect(read "config/initializers/version.rb").to include "APP_VERSION = '1'"
+        expect(all_output).not_to include 'Capistrano deploying to production'
+      end
+    end
+
+    context "given an version.rb exists with APP_VERSION set to 5" do
+      let(:expected_version) { 6 }
+
+      before do
+        write_file "config/initializers/version.rb", <<~RUBY
+          APP_VERSION = '5'
+        RUBY
+      end
+
+      it "creates a new release with version number and does not deploy" do
+        run_ed "release"
+
+        expect(last_command_started).to have_exit_status(0)
+        expect(all_output).to include("Release #{expected_version} created with tag #{expected_release_tag}")
+        expect(read "config/initializers/version.rb").to include "APP_VERSION = '6'"
+        expect(all_output).not_to include 'Capistrano deploying'
+      end
+    end
+
+    context "if most recent commit is a release commit" do
+      before do
+        write_file "config/initializers/version.rb", <<~RUBY
+          APP_VERSION = '5'
+        RUBY
+        git.add "config/initializers/version.rb"
+        git.commit "Bumped to version 5 [skip ci]"
+      end
+
+      specify "it does not create a new release" do
+        run_ed "release"
+
+        expect(last_command_started).to have_exit_status 0
+        expect(all_output).to include "Release 5 has already been created on the most recent commit"
+      end
+    end
+
+    it "deploys the release if the flag is supplied" do
+      run_ed 'release --deploy production'
+
+      expect(last_command_started).to have_exit_status(0)
+      expect(all_output).to include('Deploying to production...')
+      expect(all_output).to include 'Capistrano deploying to production'
+    end
+
+    it 'does not deploy a second environment if the first environment deployment fails' do
+      run_ed 'release --deploy demo:production'
+
+      expect(last_command_started).to have_exit_status(1)
+      expect(all_output).to include('Deploying to demo...')
+      expect(all_output).to include('Deployment failed - please review output before deploying again')
+      expect(all_output).not_to include('Deploying to production...')
+      expect(all_output).not_to include 'Capistrano deploying to production'
+    end
+  end
+
+  context "given EpiDeploy.create_release_commit option is not configured" do
+    it_behaves_like "configured to not create release commit"
+  end
+
+  context "given EpiDeploy.create_release_commit option is set to false" do
+    before do
+      write_file "config/epi_deploy.rb", <<~RUBY
+        EpiDeploy.create_release_commit = false
+      RUBY
+    end
+
+    it_behaves_like "configured to not create release commit"
   end
 end

--- a/spec/features/release_spec.rb
+++ b/spec/features/release_spec.rb
@@ -9,6 +9,69 @@ describe "Release", :bundle, type: :aruba do
   let(:expected_version) {}
   let(:expected_release_tag) { "#{Time.now.strftime("%Y%b%d-%H%M")}-#{short_commit_hash}-v#{expected_version}".downcase }
 
+  shared_examples "deployed release" do
+    it "deploys the release if the flag is supplied" do
+      run_ed 'release --deploy production'
+
+      expect(last_command_started).to have_exit_status(0)
+      expect(all_output).to include('Deploying to production...')
+      expect(all_output).to include 'Capistrano deploying to production'
+    end
+
+    it 'does not deploy a second environment if the first environment deployment fails' do
+      run_ed 'release --deploy demo:production'
+
+      expect(last_command_started).to have_exit_status(1)
+      expect(all_output).to include('Deploying to demo...')
+      expect(all_output).to include('Deployment failed - please review output before deploying again')
+      expect(all_output).not_to include('Deploying to production...')
+      expect(all_output).not_to include 'Capistrano deploying to production'
+    end
+  end
+
+  shared_context "release with pending changes" do
+    context "if the working tree is dirty" do
+      before do
+        write_file "Gemfile", "test contents"
+      end
+
+      specify "it fails to create a release and prints a message" do
+        run_ed "release"
+
+        expect(last_command_started).to have_exit_status(1)
+        expect(all_output).to include "You have pending changes - please commit or stash them, or pass the --allow-dirty flag."
+      end
+
+      specify "it creates a release if the --allow-dirty flag is supplied and retains the dirty working tree" do
+        run_ed "release --allow-dirty"
+
+        expect(last_command_started).to have_exit_status(0)
+        expect(git.status.changed.keys).to contain_exactly "Gemfile"
+      end
+    end
+
+    context "if the index is dirty" do
+      before do
+        write_file "Gemfile", "test contents"
+        git.add "Gemfile"
+      end
+
+      specify "it fails to create a release and prints a message" do
+        run_ed "release"
+
+        expect(last_command_started).to have_exit_status(1)
+        expect(all_output).to include "You have pending changes - please commit or stash them, or pass the --allow-dirty flag."
+      end
+
+      specify "it creates a release if the --allow-dirty flag is supplied and resets any staged changes back to the working tree" do
+        run_ed "release --allow-dirty"
+
+        expect(last_command_started).to have_exit_status(0)
+        expect(git.status.changed.keys).to contain_exactly "Gemfile"
+      end
+    end
+  end
+
   shared_examples "configured to not create release commit" do
     let(:short_commit_hash) { git.log.first.sha[0..6] }
 
@@ -51,23 +114,8 @@ describe "Release", :bundle, type: :aruba do
       end
     end
 
-    it "deploys the release if the flag is supplied" do
-      run_ed 'release --deploy production'
-
-      expect(last_command_started).to have_exit_status(0)
-      expect(all_output).to include('Deploying to production...')
-      expect(all_output).to include 'Capistrano deploying to production'
-    end
-
-    it 'does not deploy a second environment if the first environment deployment fails' do
-      run_ed 'release --deploy demo:production'
-
-      expect(last_command_started).to have_exit_status(1)
-      expect(all_output).to include('Deploying to demo...')
-      expect(all_output).to include('Deployment failed - please review output before deploying again')
-      expect(all_output).not_to include('Deploying to production...')
-      expect(all_output).not_to include 'Capistrano deploying to production'
-    end
+    it_behaves_like "release with pending changes"
+    it_behaves_like "deployed release"
   end
 
   context "given EpiDeploy.create_release_commit option is configured to true" do
@@ -128,23 +176,9 @@ describe "Release", :bundle, type: :aruba do
       end
     end
 
-    it "deploys the release if the flag is supplied" do
-      run_ed 'release --deploy production'
+    it_behaves_like "release with pending changes"
 
-      expect(last_command_started).to have_exit_status(0)
-      expect(all_output).to include('Deploying to production...')
-      expect(all_output).to include 'Capistrano deploying to production'
-    end
-
-    it 'does not deploy a second environment if the first environment deployment fails' do
-      run_ed 'release --deploy demo:production'
-
-      expect(last_command_started).to have_exit_status(1)
-      expect(all_output).to include('Deploying to demo...')
-      expect(all_output).to include('Deployment failed - please review output before deploying again')
-      expect(all_output).not_to include('Deploying to production...')
-      expect(all_output).not_to include 'Capistrano deploying to production'
-    end
+    it_behaves_like "deployed release"
   end
 
   context "given EpiDeploy.create_release_commit option is not configured" do

--- a/spec/features/release_spec.rb
+++ b/spec/features/release_spec.rb
@@ -1,40 +1,38 @@
 require 'spec_helper'
 require 'support/aruba_helper'
 
-describe "Release", type: :aruba do
-  it "creates a new release" do
-    run_command_and_stop 'bundle install --quiet'
+describe "Release", :bundle, type: :aruba do
+  context "given EpiDeploy.create_release_commit option is configured to true" do
+    before do
+      write_file "config/epi_deploy.rb", <<~RUBY
+        EpiDeploy.create_release_commit = true
+      RUBY
+    end
 
-    run_ed "release"
+    it "creates a new release" do
+      run_ed "release"
 
-    expect(last_command_started).to have_exit_status(0)
-    expect(all_output).to include("Release 1 created with tag #{Time.now.year}")
-    expect(all_output).not_to include 'Capistrano deploying to production'
-  end
+      expect(last_command_started).to have_exit_status(0)
+      expect(all_output).to include("Release 1 created with tag #{Time.now.year}")
+      expect(all_output).not_to include 'Capistrano deploying to production'
+    end
 
-  it "deploys the release if the flag is supplied" do
-    run_command_and_stop 'git tag -a example_tag -m "For testing"'  # Create a pretend release
-    run_command_and_stop 'git push'
-    run_command_and_stop 'bundle install --quiet'
+    it "deploys the release if the flag is supplied" do
+      run_ed 'release --deploy production'
 
-    run_ed 'release --deploy production'
+      expect(last_command_started).to have_exit_status(0)
+      expect(all_output).to include('Deploying to production...')
+      expect(all_output).to include 'Capistrano deploying to production'
+    end
 
-    expect(last_command_started).to have_exit_status(0)
-    expect(all_output).to include('Deploying to production...')
-    expect(all_output).to include 'Capistrano deploying to production'
-  end
+    it 'does not deploy a second environment if the first environment deployment fails' do
+      run_ed 'release --deploy demo:production'
 
-  it 'does not deploy a second environment if the first environment deployment fails' do
-    run_command_and_stop 'git tag -a example_tag -m "For testing"'  # Create a pretend release
-    run_command_and_stop 'git push --tags'
-    run_command_and_stop 'bundle install --quiet'
-
-    run_ed 'release --deploy demo:production'
-
-    expect(last_command_started).to have_exit_status(1)
-    expect(all_output).to include('Deploying to demo...')
-    expect(all_output).to include('Deployment failed - please review output before deploying again')
-    expect(all_output).not_to include('Deploying to production...')
-    expect(all_output).not_to include 'Capistrano deploying to production'
+      expect(last_command_started).to have_exit_status(1)
+      expect(all_output).to include('Deploying to demo...')
+      expect(all_output).to include('Deployment failed - please review output before deploying again')
+      expect(all_output).not_to include('Deploying to production...')
+      expect(all_output).not_to include 'Capistrano deploying to production'
+    end
   end
 end

--- a/spec/features/release_spec.rb
+++ b/spec/features/release_spec.rb
@@ -127,6 +127,12 @@ describe "Release", :bundle, type: :aruba do
       RUBY
     end
 
+    specify "it prints a deprecation warning that prompts me to switch to using" do
+      run_ed "release"
+
+      expect(all_output).to include "[Deprecation Warning] Deploying with tags will be the only option"
+    end
+
     context "given no version.rb is found" do
       let(:expected_version) { 1 }
 

--- a/spec/features/release_spec.rb
+++ b/spec/features/release_spec.rb
@@ -29,7 +29,7 @@ describe "Release", :bundle, type: :aruba do
     end
   end
 
-  shared_context "release with pending changes" do
+  shared_examples "release with pending changes" do
     context "if the working tree is dirty" do
       before do
         write_file "Gemfile", "test contents"
@@ -110,7 +110,7 @@ describe "Release", :bundle, type: :aruba do
       specify "it prints a message prompting me to delete the file" do
         run_ed "release"
 
-        expect(all_output).to include "The file config/initializers/version.rb can be deleted as it is no longer needed"
+        expect(all_output).to include "The file config/initializers/version.rb should be deleted as it is no longer needed by epi_deploy"
       end
     end
 

--- a/spec/features/release_spec.rb
+++ b/spec/features/release_spec.rb
@@ -127,10 +127,10 @@ describe "Release", :bundle, type: :aruba do
       RUBY
     end
 
-    specify "it prints a deprecation warning that prompts me to switch to using" do
+    specify "it prints a deprecation warning that prompts me to switch to commitless releases" do
       run_ed "release"
 
-      expect(all_output).to include "[Deprecation Warning] Deploying with tags will be the only option"
+      expect(all_output).to include "[Deprecation Warning] The create_release_commit option should only be used"
     end
 
     context "given no version.rb is found" do

--- a/spec/features/release_spec.rb
+++ b/spec/features/release_spec.rb
@@ -37,6 +37,20 @@ describe "Release", :bundle, type: :aruba do
       end
     end
 
+    context "if the file config/initializers/version.rb exists" do
+      before do
+        write_file "config/initializers/version.rb", <<~RUBY
+          APP_VERSION = '5'
+        RUBY
+      end
+
+      specify "it prints a message prompting me to delete the file" do
+        run_ed "release"
+
+        expect(all_output).to include "The file config/initializers/version.rb can be deleted as it is no longer needed"
+      end
+    end
+
     it "deploys the release if the flag is supplied" do
       run_ed 'release --deploy production'
 

--- a/spec/fixtures/test_app/Capfile
+++ b/spec/fixtures/test_app/Capfile
@@ -1,3 +1,6 @@
 require 'capistrano/setup'
 require 'capistrano/deploy'
 require 'capistrano/epi_deploy'
+
+require 'capistrano/scm/git'
+install_plugin Capistrano::SCM::Git

--- a/spec/lib/epi_deploy/command_spec.rb
+++ b/spec/lib/epi_deploy/command_spec.rb
@@ -21,7 +21,7 @@ end
 
 class MockRelease
 
-  def create!; true; end
+  def create!(...); true; end
   def deploy!(environments); end
   def version; 5; end
   def tag; 'nice-taggy'; end
@@ -34,12 +34,13 @@ class MockRelease
 end
 
 describe "Command" do
-  before do
-    allow_any_instance_of(EpiDeploy::Helpers).to receive_messages(print_notice: nil, print_success: nil, print_failure_and_abort: nil)
-  end
-
   let(:options) { double(to_hash: {}) }
   let(:args) { [] }
+
+  before do
+    allow_any_instance_of(EpiDeploy::Helpers).to receive_messages(print_notice: nil, print_success: nil, print_failure_and_abort: nil)
+    allow(options).to receive(:[]).with(:allow_dirty).and_return(false)
+  end
 
   describe "release" do
     subject { EpiDeploy::Command.new options, args, MockRelease }

--- a/spec/lib/epi_deploy/deployer_spec.rb
+++ b/spec/lib/epi_deploy/deployer_spec.rb
@@ -152,6 +152,12 @@ RSpec.describe EpiDeploy::Deployer do
           subject.deploy! ['demo', 'production']
         end.to raise_error system_exit
       end
+
+      it "warns that deploying with tags will be the only behaviour in the next release" do
+        subject.deploy! %w[ production ]
+
+        expect(Kernel).to have_received(:warn).with including "[Deprecation Warning] Deploying with tags will be the only option"
+      end
     end
   end
 end

--- a/spec/lib/epi_deploy/deployer_spec.rb
+++ b/spec/lib/epi_deploy/deployer_spec.rb
@@ -146,10 +146,10 @@ RSpec.describe EpiDeploy::Deployer do
         expect { subject.deploy! ['demo', 'production'] }.to raise_error system_exit
       end
 
-      it "warns that deploying with tags will be the only behaviour in the next release" do
+      it "warns that branchful deployments will be the only behaviour in a future version" do
         subject.deploy! %w[ production ]
 
-        expect(Kernel).to have_received(:warn).with including "[Deprecation Warning] Deploying with tags will be the only option"
+        expect(Kernel).to have_received(:warn).with including "[Deprecation Warning] Branchless deployments will be the only option"
       end
     end
   end

--- a/spec/lib/epi_deploy/deployer_spec.rb
+++ b/spec/lib/epi_deploy/deployer_spec.rb
@@ -112,23 +112,20 @@ RSpec.describe EpiDeploy::Deployer do
 
     context 'given that timestamped deploy tags have not been enabled' do
       before do
+        allow(Kernel).to receive_messages warn: nil, system: true
         allow(EpiDeploy).to receive(:use_timestamped_deploy_tags).and_return(false)
       end
 
       it "runs the capistrano deploy task for single-customer environments" do
-        expect(Kernel).to receive(:system).with("BRANCH=#{release.commit} ED_REF=test bundle exec cap demo deploy").and_return(true)
+        subject.deploy! %w[demo]
 
-        expect do
-          subject.deploy! %w[demo]
-        end.not_to raise_error
+        expect(Kernel).to have_received(:system).with("BRANCH=#{release.commit} ED_REF=test bundle exec cap demo deploy")
       end
 
       it 'runs the capistrano deploy_all task for multi-customer environments' do
-        expect(Kernel).to receive(:system).with("BRANCH=#{release.commit} ED_REF=test bundle exec cap production deploy_all").and_return(true)
+        subject.deploy! %w[production]
 
-        expect do
-          subject.deploy! %w[production]
-        end.not_to raise_error
+        expect(Kernel).to have_received(:system).with("BRANCH=#{release.commit} ED_REF=test bundle exec cap production deploy_all")
       end
 
       it 'creates a branch for each deployment environment' do
@@ -137,9 +134,7 @@ RSpec.describe EpiDeploy::Deployer do
         expect(git_wrapper).to receive(:create_or_update_branch).with('demo', release.commit)
         expect(git_wrapper).to receive(:create_or_update_branch).with('production', release.commit).at_least(:once)
 
-        expect do
-          subject.deploy! ['production.epigenesys', 'production.genesys', 'demo']
-        end.not_to raise_error
+        subject.deploy! ['production.epigenesys', 'production.genesys', 'demo']
       end
 
       it 'creates a branch for a deployment stage each if it does not succeed but not for subsequent environments' do
@@ -148,9 +143,7 @@ RSpec.describe EpiDeploy::Deployer do
         expect(git_wrapper).to receive(:create_or_update_branch).with('demo', release.commit)
         expect(git_wrapper).not_to receive(:create_or_update_branch).with('production', any_args)
 
-        expect do
-          subject.deploy! ['demo', 'production']
-        end.to raise_error system_exit
+        expect { subject.deploy! ['demo', 'production'] }.to raise_error system_exit
       end
 
       it "warns that deploying with tags will be the only behaviour in the next release" do

--- a/spec/lib/epi_deploy/git_wrapper_spec.rb
+++ b/spec/lib/epi_deploy/git_wrapper_spec.rb
@@ -3,30 +3,29 @@ require 'epi_deploy/config'
 require 'epi_deploy/git_wrapper'
 
 describe EpiDeploy::GitWrapper do
-  let(:mocked_git) { double(:git, current_branch: current_branch, add_tag: true, push: true) }
+  subject { described_class.new git: }
+
+  let(:git) { instance_spy Git::Base, current_branch:, add_tag: true, push: true }
   let(:commit) { 'caa2c06f96cb0e52cdc6059014bc69bd94573d7a592b8c380bca5348e1f6806e0e9ad9bd12d7a78b' }
   let(:current_branch) { 'main' }
 
-  before do
-    allow(subject).to receive(:git).and_return(mocked_git)
-  end
-
   describe '#create_or_update_tag' do
     it 'adds a new tag for the stage to the commit' do
-      expect(mocked_git).to receive(:push).with('origin', 'refs/tags/production', delete: true)
-      expect(mocked_git).to receive(:add_tag).with('production', commit, any_args)
-      expect(mocked_git).to receive(:push).with('origin', 'refs/tags/production')
-
       subject.create_or_update_tag 'production', commit
+
+      expect(git).to have_received(:push).with('origin', 'refs/tags/production', delete: true)
+      expect(git).to have_received(:add_tag).with('production', commit, any_args)
+      expect(git).to have_received(:push).with('origin', 'refs/tags/production')
     end
   end
 
   describe '#create_or_update_branch' do
     it 'creates or moves the branch to the commit' do
-      expect(Kernel).to receive(:system).with("git branch -f production #{commit}").and_return(true)
-      expect(mocked_git).to receive(:push).with('origin', 'refs/heads/production', force: true, tags: false
-)
+      allow(Kernel).to receive(:system).with("git branch -f production #{commit}").and_return(true)
+
       subject.create_or_update_branch('production', commit)
+
+      expect(git).to have_received(:push).with('origin', 'refs/heads/production', force: true, tags: false)
     end
   end
 
@@ -58,66 +57,56 @@ describe EpiDeploy::GitWrapper do
 
   describe '#current_branch' do
     specify 'It returns the current_branch from git' do
-      expect(subject.current_branch).to eq mocked_git.current_branch
+      expect(subject.current_branch).to eq git.current_branch
     end
   end
 
   describe '#delete_branches' do
-    let(:branches) { ['production', 'demo'] }
-    let(:local_branches) { [] }
+    let(:branches) { instance_double Git::Branches, local: local_branches, remote: remote_branches }
+    let(:production_branch) { instance_spy Git::Branch, delete: true, name: "production" }
+    let(:demo_branch) { instance_spy Git::Branch, delete: true, name: "demo" }
+    let(:staging_branch) { instance_spy Git::Branch, delete: true, name: "staging" }
+    let(:local_branches) {
+      [
+        production_branch,
+        demo_branch,
+      ]
+    }
+    let(:remote_branches) {
+      [
+        production_branch,
+        staging_branch,
+      ]
+    }
 
     before do
-      allow(subject).to receive(:local_branches).and_return(local_branches)
+      allow(git).to receive(:branches).and_return(branches)
+      allow(Kernel).to receive(:system).and_return(true)
     end
 
-    context 'if all the branches exist as local branches' do
-      let(:production_branch) { double('production branch', delete: true) }
-      let(:demo_branch) { double('demo branch', delete: true) }
-      let(:local_branches) {
-        [
-          production_branch,
-          demo_branch,
-        ]
-      }
+    it "only deletes branches locally if they exist" do
+      subject.delete_branches %w[ production demo staging training ]
 
-      specify 'it deletes each branch from the remote' do
-        allow(production_branch).to receive(:delete)
-        allow(demo_branch).to receive(:delete)
-
-        expect(subject).to receive(:run_custom_command).with("git push origin refs/heads/production refs/heads/demo --delete")
-
-        subject.delete_branches(branches)
-      end
-
-      specify 'it deletes each branch locally' do
-        allow(subject).to receive(:run_custom_command)
-        expect(production_branch).to receive(:delete)
-        expect(demo_branch).to receive(:delete)
-
-        subject.delete_branches(branches)
+      aggregate_failures do
+        expect(production_branch).to have_received :delete
+        expect(demo_branch).to have_received :delete
+        expect(staging_branch).not_to have_received :delete
       end
     end
 
-    context 'if not all the branches exist as local branches' do
-      let(:production_branch) { double('production branch') }
-      let(:demo_branch) { double('demo branch') }
-      let(:local_branches) { [production_branch] }
+    it "only deletes branches on the remote if they exist there" do
+      subject.delete_branches %w[ production demo staging training ]
 
-      specify 'it deletes each branch from the remote' do
-        allow(production_branch).to receive(:delete)
+      expect(Kernel).to have_received(:system).with("git push origin refs/heads/production refs/heads/staging --delete")
+    end
 
-        expect(subject).to receive(:run_custom_command).with("git push origin refs/heads/production refs/heads/demo --delete")
+    it "does not nothing if the branches do not exist locally or remotely" do
+      subject.delete_branches %w[ training ]
 
-        subject.delete_branches(branches)
-      end
-
-      specify 'it deletes only the branches that exist locally' do
-        allow(subject).to receive(:run_custom_command)
-        expect(production_branch).to receive(:delete)
-        expect(demo_branch).not_to receive(:delete)
-
-        subject.delete_branches(branches)
-      end
+      expect(production_branch).not_to have_received :delete
+      expect(demo_branch).not_to have_received :delete
+      expect(staging_branch).not_to have_received :delete
+      expect(Kernel).not_to have_received(:system).with including "git push origin"
     end
   end
 end

--- a/spec/lib/epi_deploy/release_spec.rb
+++ b/spec/lib/epi_deploy/release_spec.rb
@@ -232,11 +232,11 @@ describe EpiDeploy::Release do
         end
 
         specify "it prints a message to prompt the file to be deleted" do
-          allow($stdout).to receive(:puts)
+          allow(Kernel).to receive(:warn)
 
           subject.create!
 
-          expect($stdout).to have_received(:puts).with including "The file config/initializers/version.rb can be deleted as it is no longer needed"
+          expect(Kernel).to have_received(:warn).with including "The file config/initializers/version.rb can be deleted as it is no longer needed"
         end
       end
     end

--- a/spec/lib/epi_deploy/release_spec.rb
+++ b/spec/lib/epi_deploy/release_spec.rb
@@ -25,7 +25,10 @@ describe EpiDeploy::Release do
   let(:abort_exception) { RuntimeError.new "abort" }
   let(:expected_release_tag) { "#{Time.now.strftime("%Y%b%d-%H%M")}-#{git_wrapper.short_commit_hash}-v#{version + 1}".downcase }
 
-  before { allow(Kernel).to receive(:abort).and_raise(abort_exception) }
+  before do
+    allow(Kernel).to receive(:abort).and_raise(abort_exception)
+    allow($stdout).to receive(:puts)
+  end
 
   describe "#create!" do
     context "given EpiDeploy.create_release_commit option is configured to true" do
@@ -116,7 +119,7 @@ describe EpiDeploy::Release do
           expect(Kernel).to have_received(:abort).with including "You have pending changes - please commit or stash them, or pass the --allow-dirty flag."
         end
 
-        specify "it creates a release if allow_empty is truthy" do
+        specify "it creates a release if allow_dirty is truthy" do
           expect(subject.create! allow_dirty: true).to be true
         end
       end
@@ -188,7 +191,7 @@ describe EpiDeploy::Release do
           expect(Kernel).to have_received(:abort).with including "You have pending changes - please commit or stash them, or pass the --allow-dirty flag."
         end
 
-        specify "it creates a release if allow_empty is truthy" do
+        specify "it creates a release if allow_dirty is truthy" do
           expect(subject.create! allow_dirty: true).to be true
         end
       end
@@ -206,11 +209,13 @@ describe EpiDeploy::Release do
         end
 
         specify "it does not create a new tag" do
+          subject.create!
+
           expect(git_wrapper).not_to have_received(:create_or_update_tag)
         end
       end
 
-      context "if there are not any release tags" do
+      context "if there are no release tags" do
         let(:version) { 0 }
 
         before do
@@ -236,7 +241,7 @@ describe EpiDeploy::Release do
 
           subject.create!
 
-          expect($stdout).to have_received(:puts).with including "The file config/initializers/version.rb can be deleted as it is no longer needed"
+          expect($stdout).to have_received(:puts).with including "The file config/initializers/version.rb should be deleted as it is no longer needed by epi_deploy"
         end
       end
     end

--- a/spec/lib/epi_deploy/release_spec.rb
+++ b/spec/lib/epi_deploy/release_spec.rb
@@ -209,6 +209,22 @@ describe EpiDeploy::Release do
           expect(git_wrapper).to have_received(:create_or_update_tag).with expected_release_tag
         end
       end
+
+      context "when config/initializers/version.rb exists" do
+        let(:app_version) { instance_double EpiDeploy::AppVersion, version_file_exists?: true }
+
+        before do
+          allow(app_version).to receive(:version=)
+        end
+
+        specify "it prints a message to prompt the file to be deleted" do
+          allow($stdout).to receive(:puts)
+
+          subject.create!
+
+          expect($stdout).to have_received(:puts).with including "The file config/initializers/version.rb can be deleted as it is no longer needed"
+        end
+      end
     end
   end
 end

--- a/spec/lib/epi_deploy/release_spec.rb
+++ b/spec/lib/epi_deploy/release_spec.rb
@@ -25,7 +25,10 @@ describe EpiDeploy::Release do
   let(:abort_exception) { RuntimeError.new "abort" }
   let(:expected_release_tag) { "#{Time.now.strftime("%Y%b%d-%H%M")}-#{git_wrapper.short_commit_hash}-v#{version + 1}".downcase }
 
-  before { allow(Kernel).to receive(:abort).and_raise(abort_exception) }
+  before do
+    allow(Kernel).to receive(:abort).and_raise(abort_exception)
+    allow(Kernel).to receive(:warn)
+  end
 
   describe "#create!" do
     context "given EpiDeploy.create_release_commit option is configured to true" do

--- a/spec/lib/epi_deploy/release_spec.rb
+++ b/spec/lib/epi_deploy/release_spec.rb
@@ -104,7 +104,7 @@ describe EpiDeploy::Release do
 
         specify "it aborts with an error message" do
           expect { subject.create! }.to raise_error abort_exception
-          expect(Kernel).to have_received(:abort).with including "You can only create a release on the main or master branch. Please switch to main or master and try again."
+          expect(Kernel).to have_received(:abort).with including "You can only create a release on the main or master branch - please switch to main or master."
         end
       end
 
@@ -113,7 +113,11 @@ describe EpiDeploy::Release do
 
         specify "it aborts with an error message" do
           expect { subject.create! }.to raise_error abort_exception
-          expect(Kernel).to have_received(:abort).with including "You have pending changes, please commit or stash them and try again."
+          expect(Kernel).to have_received(:abort).with including "You have pending changes - please commit or stash them."
+        end
+
+        specify "it creates a release if allow_empty is truthy" do
+          expect(subject.create! allow_dirty: true).to be true
         end
       end
 
@@ -172,7 +176,7 @@ describe EpiDeploy::Release do
 
         specify "it aborts with an error message" do
           expect { subject.create! }.to raise_error abort_exception
-          expect(Kernel).to have_received(:abort).with including "You can only create a release on the main or master branch. Please switch to main or master and try again."
+          expect(Kernel).to have_received(:abort).with including "You can only create a release on the main or master branch - please switch to main or master."
         end
       end
 
@@ -181,7 +185,11 @@ describe EpiDeploy::Release do
 
         specify "it aborts with an error message" do
           expect { subject.create! }.to raise_error abort_exception
-          expect(Kernel).to have_received(:abort).with including "You have pending changes, please commit or stash them and try again."
+          expect(Kernel).to have_received(:abort).with including "You have pending changes - please commit or stash them."
+        end
+
+        specify "it creates a release if allow_empty is truthy" do
+          expect(subject.create! allow_dirty: true).to be true
         end
       end
 

--- a/spec/lib/epi_deploy/release_spec.rb
+++ b/spec/lib/epi_deploy/release_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'time'
 
 require 'spec_helper'
@@ -5,89 +7,207 @@ require 'epi_deploy/stages_extractor'
 require 'epi_deploy/release'
 
 describe EpiDeploy::Release do
-  subject { described_class.new(reference: "test", git_wrapper: git_wrapper, commit: "caa2c06f96cb0e52cdc6059014bc69bd94573d7a592b8c380bca5348e1f6806e0e9ad9bd12d7a78b", app_version: app_version) }
+  subject { described_class.new(reference: "test", git_wrapper:, commit: "caa2c06f96cb0e52cdc6059014bc69bd94573d7a592b8c380bca5348e1f6806e0e9ad9bd12d7a78b", app_version:) }
 
-  let(:git_wrapper) { instance_spy(EpiDeploy::GitWrapper, on_primary_branch?: true, pending_changes?: false, short_commit_hash: "abcdef12", current_branch: "main") }
-  let(:app_version) { instance_spy(EpiDeploy::AppVersion, version: 42, bump: 42, version_file_path: '', "latest_release_tag=": nil, save!: true) }
+  let(:version) { 41 }
+  let(:git_wrapper) {
+    instance_spy(
+      EpiDeploy::GitWrapper,
+      on_primary_branch?: true,
+      pending_changes?: false,
+      short_commit_hash: "abcdef12",
+      current_branch: "main",
+      most_recent_release_tag: "2026jun08-1215-4bc69b-v#{version}",
+      release_tag_list: ["2026jun08-1215-4bc69b-v#{version}"],
+    )
+  }
+  let(:app_version) { nil }
+  let(:abort_exception) { RuntimeError.new "abort" }
+  let(:expected_release_tag) { "#{Time.now.strftime("%Y%b%d-%H%M")}-#{git_wrapper.short_commit_hash}-v#{version + 1}".downcase }
 
-  before do
-    allow(git_wrapper).to receive(:most_recent_commit).and_return(instance_double(Git::Object::Commit, message: 'Some non-release commit'))
-  end
+  before { allow(Kernel).to receive(:abort).and_raise(abort_exception) }
 
   describe "#create!" do
     context "given EpiDeploy.create_release_commit option is configured to true" do
-      before { allow(EpiDeploy).to receive(:create_release_commit?).and_return(true) }
+      let(:app_version) {
+        instance_spy(
+          EpiDeploy::AppVersion,
+          version:,
+          bump: version + 1,
+          version_file_path: '',
+          "latest_release_tag=": nil,
+          save!: true
+        )
+      }
 
-      describe "preconditions" do
-        it "can only be done on the primary branch" do
-          allow(git_wrapper).to receive(:on_primary_branch?).and_return(false)
-          allow(Kernel).to receive(:abort)
-
-          subject.create!
-
-          expect(Kernel).to have_received(:abort).with including "You can only create a release on the main or master branch. Please switch to main or master and try again."
-        end
-
-        it "errors when pending changes exist" do
-          allow(git_wrapper).to receive(:pending_changes?).and_return(true)
-          allow(Kernel).to receive(:abort)
-
-          subject.create!
-
-          expect(Kernel).to have_received(:abort).with including "You have pending changes, please commit or stash them and try again."
-        end
+      before do
+        allow(EpiDeploy).to receive(:create_release_commit?).and_return(true)
+        allow(git_wrapper).to receive(:most_recent_commit).and_return(instance_double(Git::Object::Commit, message: 'Some non-release commit'))
       end
 
-      it "performs a git pull to ensure code is the latest" do
-        expect(subject.create!).to be true
-
-        expect(git_wrapper).to have_received(:pull)
-      end
-
-      it "bumps the version number" do
-        expect(subject.create!).to be true
-
-        expect(app_version).to have_received(:bump)
-      end
-
-      it "commits the new version number" do
-        expect(subject.create!).to be true
-
-        expect(git_wrapper).to have_received(:commit).with('Bumped to version 42 [skip ci]')
-      end
-
-      context 'given that the date and time is 2024-12-1 16:15:00' do
-        let(:expected_release_tag) { "#{Time.now.strftime("%Y%b%d-%H%M")}-#{git_wrapper.short_commit_hash}-v#{app_version.version}".downcase }
-
-        before do
-          allow(EpiDeploy).to receive(:create_release_commit?).and_return(true)
-        end
-
-        it 'sets the latest release tag in the version the newly-created tag' do
+      context "if a release can be created" do
+        it "returns true" do
           expect(subject.create!).to be true
+        end
+
+        it "performs a git pull to ensure code is the latest" do
+          subject.create!
+
+          expect(git_wrapper).to have_received(:pull)
+        end
+
+        it "bumps the version number" do
+          subject.create!
+
+          expect(app_version).to have_received(:bump)
+        end
+
+        it "commits the new version number" do
+          subject.create!
+
+          expect(git_wrapper).to have_received(:commit).with('Bumped to version 42 [skip ci]')
+        end
+
+        it 'sets the latest release tag in the app version to the newly-created tag' do
+          subject.create!
 
           expect(app_version).to have_received(:latest_release_tag=).with expected_release_tag
         end
 
         it "creates a tag in the format YYYYmonDD-HHMM-CommitRef-version for the new commit" do
-          expect(subject.create!).to be true
+          subject.create!
 
           expect(git_wrapper).to have_received(:create_or_update_tag).with expected_release_tag, push: false
         end
+
+        it "pushes the new version to primary branch to reduce the chance of version number collisions" do
+          subject.create!
+
+          expect(git_wrapper).to have_received(:push).with "main", tags: true
+        end
+
+        it "sets #tag to the newly-created tag" do
+          subject.create!
+
+          expect(subject.tag).to eq expected_release_tag
+        end
       end
 
-      it "pushes the new version to primary branch to reduce the chance of version number collisions" do
-        expect(subject.create!).to be true
+      context "if the primary branch is not checked out" do
+        before { allow(git_wrapper).to receive(:on_primary_branch?).and_return(false) }
 
-        expect(git_wrapper).to have_received(:push).with "main", tags: true
+        specify "it aborts with an error message" do
+          expect { subject.create! }.to raise_error abort_exception
+          expect(Kernel).to have_received(:abort).with including "You can only create a release on the main or master branch. Please switch to main or master and try again."
+        end
       end
 
-      it 'does not create a new release if the most recent commit is a release commit' do
-        allow(git_wrapper).to receive(:most_recent_commit).and_return(instance_double(Git::Object::Commit, message: 'Bumped to version 12 [skip ci]'))
+      context "if there are pending changes" do
+        before { allow(git_wrapper).to receive(:pending_changes?).and_return(true) }
 
-        expect(subject.create!).to be false
+        specify "it aborts with an error message" do
+          expect { subject.create! }.to raise_error abort_exception
+          expect(Kernel).to have_received(:abort).with including "You have pending changes, please commit or stash them and try again."
+        end
+      end
 
-        expect(git_wrapper).not_to have_received(:create_or_update_tag)
+      context "if the most recent commit is a release commit" do
+        before { allow(git_wrapper).to receive(:most_recent_commit).and_return(instance_double(Git::Object::Commit, message: 'Bumped to version 12 [skip ci]')) }
+
+        specify "it returns false and does not create a release commit" do
+          expect(subject.create!).to be false
+
+          expect(git_wrapper).not_to have_received(:create_or_update_tag)
+          expect(git_wrapper).not_to have_received(:commit)
+        end
+      end
+    end
+
+    context "given EpiDeploy.create_release_commit option is configured to false" do
+      before do
+        allow(EpiDeploy).to receive(:create_release_commit?).and_return(false)
+
+        allow(git_wrapper).to receive(:git_object_for).with(git_wrapper.most_recent_release_tag).and_return(instance_double(Git::Object::Commit, sha: "3acd361a8177b06645822fe6df4ab486137709a0"))
+        allow(git_wrapper).to receive(:most_recent_commit).and_return(instance_double(Git::Object::Commit, sha: "6815f6a9dfa318871fe3ab8dce53956dc59692b5"))
+      end
+
+      context "if a release can be created" do
+        it "returns true" do
+          expect(subject.create!).to be true
+        end
+
+        it "performs a git pull to ensure code is the latest" do
+          subject.create!
+
+          expect(git_wrapper).to have_received(:pull)
+        end
+
+        it "does not create a new commit" do
+          subject.create!
+
+          expect(git_wrapper).not_to have_received(:commit)
+        end
+
+        it "creates a tag in the format YYYYmonDD-HHMM-CommitRef-version on the current commit" do
+          subject.create!
+
+          expect(git_wrapper).to have_received(:create_or_update_tag).with expected_release_tag
+        end
+
+        it "sets #tag to the newly-created tag" do
+          subject.create!
+
+          expect(subject.tag).to eq expected_release_tag
+        end
+      end
+
+      context "if the primary branch is not checked out" do
+        before { allow(git_wrapper).to receive(:on_primary_branch?).and_return(false) }
+
+        specify "it aborts with an error message" do
+          expect { subject.create! }.to raise_error abort_exception
+          expect(Kernel).to have_received(:abort).with including "You can only create a release on the main or master branch. Please switch to main or master and try again."
+        end
+      end
+
+      context "if there are pending changes" do
+        before { allow(git_wrapper).to receive(:pending_changes?).and_return(true) }
+
+        specify "it aborts with an error message" do
+          expect { subject.create! }.to raise_error abort_exception
+          expect(Kernel).to have_received(:abort).with including "You have pending changes, please commit or stash them and try again."
+        end
+      end
+
+      context "if the most recent release tag is on the most recent commit" do
+        let(:latest_commit) { instance_double(Git::Object::Commit, sha: "e0b8e2a14ae2374c5a208ce238226c7dfb17040b") }
+
+        before do
+          allow(git_wrapper).to receive(:git_object_for).with(git_wrapper.most_recent_release_tag).and_return(latest_commit)
+          allow(git_wrapper).to receive(:most_recent_commit).and_return(latest_commit)
+        end
+
+        specify "it returns false" do
+          expect(subject.create!).to be false
+        end
+
+        specify "it does not create a new tag" do
+          expect(git_wrapper).not_to have_received(:create_or_update_tag)
+        end
+      end
+
+      context "if there are not any release tags" do
+        let(:version) { 0 }
+
+        before do
+          allow(git_wrapper).to receive_messages(most_recent_release_tag: nil, release_tag_list: [])
+        end
+
+        specify "creates a new release tag with version 1" do
+          subject.create!
+
+          expect(git_wrapper).to have_received(:create_or_update_tag).with expected_release_tag
+        end
       end
     end
   end

--- a/spec/lib/epi_deploy/release_spec.rb
+++ b/spec/lib/epi_deploy/release_spec.rb
@@ -4,107 +4,91 @@ require 'spec_helper'
 require 'epi_deploy/stages_extractor'
 require 'epi_deploy/release'
 
-class MockGit
-
-  def initialize(on_primary_branch: true, pending_changes: false)
-    @on_primary_branch = on_primary_branch
-    @pending_changes = pending_changes
-  end
-  def add(files); end
-  def on_primary_branch?; @on_primary_branch; end
-  def pending_changes?; @pending_changes; end
-  def short_commit_hash; 'abc1234'; end
-  def commit(msg); end
-  def tag(name); end
-  def push(ref, **opts); end
-  def pull; end
-  def current_branch; 'main'; end
-  def create_or_update_tag(stage, commit); end
-  def delete_branches(branches); end
-  def most_recent_commit; end
-
-end
-
 describe EpiDeploy::Release do
-  let(:git_wrapper) { MockGit.new }
-  let(:app_version) { double(bump: 42, version_file_path: '', :latest_release_tag= => nil, save!: true) }
+  subject { described_class.new(reference: "test", git_wrapper: git_wrapper, commit: "caa2c06f96cb0e52cdc6059014bc69bd94573d7a592b8c380bca5348e1f6806e0e9ad9bd12d7a78b", app_version: app_version) }
+
+  let(:git_wrapper) { instance_spy(EpiDeploy::GitWrapper, on_primary_branch?: true, pending_changes?: false, short_commit_hash: "abcdef12", current_branch: "main") }
+  let(:app_version) { instance_spy(EpiDeploy::AppVersion, version: 42, bump: 42, version_file_path: '', "latest_release_tag=": nil, save!: true) }
 
   before do
-    allow(subject).to receive_messages(reference: 'test', git_wrapper: git_wrapper, commit: 'caa2c06f96cb0e52cdc6059014bc69bd94573d7a592b8c380bca5348e1f6806e0e9ad9bd12d7a78b', app_version: app_version)
-    allow(git_wrapper).to receive(:most_recent_commit).and_return(double('commit', message: 'Some non-release commit'))
+    allow(git_wrapper).to receive(:most_recent_commit).and_return(instance_double(Git::Object::Commit, message: 'Some non-release commit'))
   end
 
   describe "#create!" do
-    describe "preconditions" do
-      it "can only be done on the primary branch" do
-        allow(git_wrapper).to receive_messages(on_primary_branch?: false)
-        expect(subject).to receive(:print_failure_and_abort).with('You can only create a release on the main or master branch. Please switch to main or master and try again.')
+    context "given EpiDeploy.create_release_commit option is configured to true" do
+      before { allow(EpiDeploy).to receive(:create_release_commit?).and_return(true) }
 
-        subject.create!
+      describe "preconditions" do
+        it "can only be done on the primary branch" do
+          allow(git_wrapper).to receive(:on_primary_branch?).and_return(false)
+          allow(Kernel).to receive(:abort)
+
+          subject.create!
+
+          expect(Kernel).to have_received(:abort).with including "You can only create a release on the main or master branch. Please switch to main or master and try again."
+        end
+
+        it "errors when pending changes exist" do
+          allow(git_wrapper).to receive(:pending_changes?).and_return(true)
+          allow(Kernel).to receive(:abort)
+
+          subject.create!
+
+          expect(Kernel).to have_received(:abort).with including "You have pending changes, please commit or stash them and try again."
+        end
       end
 
-      it "errors when pending changes exist" do
-        allow(git_wrapper).to receive_messages(pending_changes?: true)
-        expect(subject).to receive(:print_failure_and_abort).with('You have pending changes, please commit or stash them and try again.')
-
-        subject.create!
-      end
-    end
-
-    it "performs a git pull to ensure code is the latest" do
-      expect(git_wrapper).to receive(:pull)
-
-      expect(subject.create!).to be true
-    end
-
-    it "stops with a warning message when a git pull fails (eg. merge errors)" do
-      expect(git_wrapper).to receive(:pull)
-
-      expect(subject.create!).to be true
-    end
-
-    it "bumps the version number" do
-      expect(app_version).to receive(:bump)
-
-      expect(subject.create!).to be true
-    end
-
-    it "commits the new version number" do
-      expect(git_wrapper).to receive(:commit).with('Bumped to version 42 [skip ci]')
-
-      expect(subject.create!).to be true
-    end
-
-    context 'given that the date and time is 2024-12-1 16:15:00' do
-      before do
-        now = Time.new 2014, 12, 1, 16, 15
-        allow(Time).to receive_messages now: now
-      end
-
-      it 'sets the latest release tag in the version the newly-created tag' do
-        expect(app_version).to receive(:latest_release_tag=).with('2014dec01-1615-abc1234-v42')
-
+      it "performs a git pull to ensure code is the latest" do
         expect(subject.create!).to be true
+
+        expect(git_wrapper).to have_received(:pull)
       end
 
-      it "creates a tag in the format YYYYmonDD-HHMM-CommitRef-version for the new commit" do
-        expect(git_wrapper).to receive(:create_or_update_tag).with('2014dec01-1615-abc1234-v42', push: false)
-
+      it "bumps the version number" do
         expect(subject.create!).to be true
+
+        expect(app_version).to have_received(:bump)
       end
-    end
 
-    it "pushes the new version to primary branch to reduce the chance of version number collisions" do
-      expect(git_wrapper).to receive(:push).with('main', tags: true)
+      it "commits the new version number" do
+        expect(subject.create!).to be true
 
-      expect(subject.create!).to be true
-    end
+        expect(git_wrapper).to have_received(:commit).with('Bumped to version 42 [skip ci]')
+      end
 
-    it 'does not create a new release if the most recent commit is a release commit' do
-      allow(git_wrapper).to receive(:most_recent_commit).and_return(double('commit', message: 'Bumped to version 12 [skip ci]'))
-      expect(git_wrapper).not_to receive(:create_or_update_tag)
+      context 'given that the date and time is 2024-12-1 16:15:00' do
+        let(:expected_release_tag) { "#{Time.now.strftime("%Y%b%d-%H%M")}-#{git_wrapper.short_commit_hash}-v#{app_version.version}".downcase }
 
-      expect(subject.create!).to be false
+        before do
+          allow(EpiDeploy).to receive(:create_release_commit?).and_return(true)
+        end
+
+        it 'sets the latest release tag in the version the newly-created tag' do
+          expect(subject.create!).to be true
+
+          expect(app_version).to have_received(:latest_release_tag=).with expected_release_tag
+        end
+
+        it "creates a tag in the format YYYYmonDD-HHMM-CommitRef-version for the new commit" do
+          expect(subject.create!).to be true
+
+          expect(git_wrapper).to have_received(:create_or_update_tag).with expected_release_tag, push: false
+        end
+      end
+
+      it "pushes the new version to primary branch to reduce the chance of version number collisions" do
+        expect(subject.create!).to be true
+
+        expect(git_wrapper).to have_received(:push).with "main", tags: true
+      end
+
+      it 'does not create a new release if the most recent commit is a release commit' do
+        allow(git_wrapper).to receive(:most_recent_commit).and_return(instance_double(Git::Object::Commit, message: 'Bumped to version 12 [skip ci]'))
+
+        expect(subject.create!).to be false
+
+        expect(git_wrapper).not_to have_received(:create_or_update_tag)
+      end
     end
   end
 end

--- a/spec/lib/epi_deploy/release_spec.rb
+++ b/spec/lib/epi_deploy/release_spec.rb
@@ -237,8 +237,6 @@ describe EpiDeploy::Release do
         end
 
         specify "it prints a message to prompt the file to be deleted" do
-          allow(Kernel).to receive(:warn)
-
           subject.create!
 
           expect(Kernel).to have_received(:warn).with including "The file config/initializers/version.rb should be deleted as it is no longer needed by epi_deploy"

--- a/spec/lib/epi_deploy/release_spec.rb
+++ b/spec/lib/epi_deploy/release_spec.rb
@@ -50,6 +50,12 @@ describe EpiDeploy::Release do
           expect(subject.create!).to be true
         end
 
+        it "calls git reset to unstage any pending changes" do
+          subject.create!
+
+          expect(git_wrapper).to have_received(:reset)
+        end
+
         it "performs a git pull to ensure code is the latest" do
           subject.create!
 

--- a/spec/lib/epi_deploy/release_spec.rb
+++ b/spec/lib/epi_deploy/release_spec.rb
@@ -113,7 +113,7 @@ describe EpiDeploy::Release do
 
         specify "it aborts with an error message" do
           expect { subject.create! }.to raise_error abort_exception
-          expect(Kernel).to have_received(:abort).with including "You have pending changes - please commit or stash them."
+          expect(Kernel).to have_received(:abort).with including "You have pending changes - please commit or stash them, or pass the --allow-dirty flag."
         end
 
         specify "it creates a release if allow_empty is truthy" do
@@ -185,7 +185,7 @@ describe EpiDeploy::Release do
 
         specify "it aborts with an error message" do
           expect { subject.create! }.to raise_error abort_exception
-          expect(Kernel).to have_received(:abort).with including "You have pending changes - please commit or stash them."
+          expect(Kernel).to have_received(:abort).with including "You have pending changes - please commit or stash them, or pass the --allow-dirty flag."
         end
 
         specify "it creates a release if allow_empty is truthy" do

--- a/spec/lib/epi_deploy/release_tag_spec.rb
+++ b/spec/lib/epi_deploy/release_tag_spec.rb
@@ -1,0 +1,92 @@
+require "spec_helper"
+
+require "epi_deploy/release_tag"
+
+RSpec.describe EpiDeploy::ReleaseTag do
+  subject { described_class.new(timestamp:, commit:, version:) }
+
+  let(:timestamp) { "2026jun20-1234" }
+  let(:commit) { "123456ab" }
+  let(:version) { "10" }
+
+  describe ".parse" do
+    it "returns an instance of ReleaseTag if the tag is valid" do
+      tag = described_class.parse "2026jun20-1234-abcdef12-v10"
+
+      expect(tag).not_to be_nil
+      expect(tag).to have_attributes timestamp: Time.new(2026, 6, 20, 12, 34), commit: "abcdef12", version: 10
+    end
+
+    it "returns nil if the timestamp is not well-formatted" do
+      tag = described_class.parse "2026jun201234-abcdef12-v10"
+
+      expect(tag).to be_nil
+    end
+
+    it "returns nil if the timestamp is missing" do
+      tag = described_class.parse "-abcdef12-v10"
+
+      expect(tag).to be_nil
+    end
+
+    it "returns nil if the commit hash is invalid" do
+      tag = described_class.parse "2026jun20-1234-sdfhsdf13-v10"
+
+      expect(tag).to be_nil
+    end
+
+    it "returns nil if the commit hash is missing" do
+      tag = described_class.parse "2026jun20-1234--v10"
+
+      expect(tag).to be_nil
+    end
+
+    it "returns nil if the version is invalid" do
+      tag = described_class.parse "2026jun20-1234-abcdef12-vsfn23ns"
+
+      expect(tag).to be_nil
+    end
+
+    it "returns nil if the version is missing" do
+      tag = described_class.parse "2026jun20-1234-abcdef12-v"
+
+      expect(tag).to be_nil
+    end
+
+    it "returns nil if the string is empty" do
+      tag = described_class.parse ""
+
+      expect(tag).to be_nil
+    end
+  end
+
+  describe "#increment" do
+    it "returns a new instance with the current timestamp, the commit hash specified, and the version number incremented" do
+      tag = subject.increment(commit: "ba654321")
+
+      aggregate_failures do
+        expect(tag).not_to be subject
+        expect(tag.timestamp).to be_within(1).of Time.now
+        expect(tag.commit).to eq "ba654321"
+        expect(tag.version).to eq 11
+      end
+    end
+
+    it "returns a new instance with the specified timestamp and commit hash, and the version number incremented if the timestamp is specified" do
+      tag = subject.increment(commit: "ba654321", timestamp: "2026jun21-1234")
+
+      aggregate_failures do
+        expect(tag).not_to be subject
+        expect(tag.timestamp).to eq Time.new(2026, 6, 21, 12, 34)
+        expect(tag.commit).to eq "ba654321"
+        expect(tag.version).to eq 11
+      end
+    end
+  end
+
+  describe "#to_s" do
+    it "returns a representation of the tag for use with Git" do
+      expect(subject.to_s).to eq "#{timestamp}-#{commit}-v#{version}"
+    end
+  end
+end

--- a/spec/lib/epi_deploy/release_tag_spec.rb
+++ b/spec/lib/epi_deploy/release_tag_spec.rb
@@ -89,4 +89,10 @@ RSpec.describe EpiDeploy::ReleaseTag do
       expect(subject.to_s).to eq "#{timestamp}-#{commit}-v#{version}"
     end
   end
+
+  describe "#name" do
+    it "returns a representation of the tag for use with Git" do
+      expect(subject.name).to eq "#{timestamp}-#{commit}-v#{version}"
+    end
+  end
 end

--- a/spec/lib/epi_deploy_spec.rb
+++ b/spec/lib/epi_deploy_spec.rb
@@ -1,0 +1,15 @@
+require "spec_helper"
+
+require "epi_deploy/config"
+
+RSpec.describe EpiDeploy do
+  before do
+    allow(Kernel).to receive :warn
+  end
+
+  it "raises a warning when EpiDeploy.create_release_commit is set to true" do
+    described_class.create_release_commit = true
+
+    expect(Kernel).to have_received(:warn).with including "[Deprecation Warning] The create_release_commit option should only be used"
+  end
+end

--- a/spec/lib/epi_deploy_spec.rb
+++ b/spec/lib/epi_deploy_spec.rb
@@ -12,4 +12,10 @@ RSpec.describe EpiDeploy do
 
     expect(Kernel).to have_received(:warn).with including "[Deprecation Warning] The create_release_commit option should only be used"
   end
+
+  it "does not raise a warning when EpiDeploy.create_release_commit is set to false" do
+    described_class.create_release_commit = false
+
+    expect(Kernel).not_to have_received(:warn)
+  end
 end


### PR DESCRIPTION
- Only delete branches on the remote and locally only if they exist
- Add deprecation warnings for using `use_timestamped_tags_for_deploy` and `create_release_commit` options
- Make setting `use_tags_for_deploy` an error condition
- Update branch notes in README and update formatting
- Use `Kernel.warn` for all deprecation warnings